### PR TITLE
Migrated from underscore into lodash & fixed authentication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.13 / 2021-04-27
+
+* Fixed authentication errors
+
 ## 2.1.12 / 2021-04-27
 
 * Added underscore package back to package.json to avoid using v0.13.1, which cause issue with importing package on Zapier platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.12 / 2021-04-27
+
+* Added underscore package back to package.json to avoid using v0.13.1, which cause issue with importing package on Zapier platform.
+
+## 2.1.11 / 2021-04-26
+
+* Migrate from underscore into lodash package
+
 ## 2.1.10 / 2021-04-26
 
 * Updated apify-client package to 0.6.0

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ Login account which has access to Apify app using `zapier login`.
 
 1. Update version of app in package.json.
 2. Deploy new version to zapier using `zapier push`.
+   -> Pushes zapier app with version from package.json into zapier platform
 3. Set the version as production using `zapier promote 1.0.1`.
+   -> Makes the app version default on Zapier platform
 4. Migrate users to new version using `zapier migrate 1.0.0 1.0.1 100%`.
+    -> Migrates users from the version into new version.
 or
 4. Deprecate old version using `zapier deprecate 1.0.0 2019-05-29`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "2.1.9",
+  "version": "2.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2389,9 +2389,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "2.1.10",
+  "version": "2.1.12",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",
@@ -19,7 +19,8 @@
     "apify-client": "^0.6.0",
     "apify-shared": "^0.7.5",
     "bluebird": "^3.7.2",
-    "underscore": "^1.13.0",
+    "lodash": "^4.17.21",
+    "underscore": "^1.12.0",
     "zapier-platform-core": "10.2.0"
   },
   "devDependencies": {

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const _ = require('underscore');
+const _ = require('lodash');
 const { WEBHOOK_EVENT_TYPE_GROUPS, BUILD_TAG_LATEST } = require('apify-shared/consts');
 const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRAWLER_ID,
     OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, ALLOWED_MEMORY_MBYTES_LIST,

--- a/src/consts.js
+++ b/src/consts.js
@@ -49,8 +49,6 @@ const ACTOR_RUN_SAMPLE = {
     },
     containerUrl: 'https://rsklyfvj7pxp.runs.apify.net',
     detailsPageUrl: 'https://my.apify.com/actors/$actId#/runs/HG7ML7M8z78YcAPEB',
-    // NOTE: This object should not be there, removed once it is fixed in Apify API.
-    runtime: {},
 };
 
 const ACTOR_RUN_OUTPUT_FIELDS = [

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -1,4 +1,4 @@
-const _ = require('underscore');
+const _ = require('lodash');
 const { APIFY_API_ENDPOINTS, DATASET_PUBLISH_FIELDS,
     DATASET_OUTPUT_FIELDS, DATASET_SAMPLE } = require('../consts');
 const { wrapRequestWithRetries } = require('../request_helpers');

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -7,7 +7,6 @@ const App = require('../index');
 const appTester = zapier.createAppTester(App);
 
 describe('authentication', () => {
-
     it('passes authentication and returns user', async () => {
         const bundle = {
             authData: {
@@ -17,5 +16,19 @@ describe('authentication', () => {
 
         const tester = await appTester(App.authentication.test, bundle);
         expect(tester).to.have.property('username');
+    });
+
+    it('throw user error if token is invalide', async () => {
+        const bundle = {
+            authData: {
+                token: 'blabla',
+            },
+        };
+        try {
+            await appTester(App.authentication.test, bundle);
+            throw new Error('Should failed');
+        } catch (err) {
+            expect(err.message).include('AuthenticationError');
+        }
     });
 });

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -1,6 +1,6 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
-const _ = require('underscore');
+const _ = require('lodash');
 const { createAndBuildActor, TEST_USER_TOKEN, apifyClient } = require('../helpers');
 const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
 
@@ -45,7 +45,7 @@ describe('create actor run', () => {
         };
 
         const fields = await appTester(App.triggers.getActorAdditionalFieldsTest.operation.perform, bundle);
-        const fieldsByKey = _.indexBy(fields, 'key');
+        const fieldsByKey = _.keyBy(fields, 'key');
 
         expect(actorFields.defaultRunOptions.build).to.be.eql(fieldsByKey.build.default);
         expect(actorFields.defaultRunOptions.timeoutSecs).to.be.eql(fieldsByKey.timeoutSecs.default);

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -1,6 +1,6 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
-const _ = require('underscore');
+const _ = require('lodash');
 const { TEST_USER_TOKEN, apifyClient, createWebScraperTask, createLegacyCrawlerTask } = require('../helpers');
 const { TASK_RUN_SAMPLE } = require('../../src/consts');
 


### PR DESCRIPTION
* Migrated from underscore into lodash
* Fixed authentication error by throwing zapier errors, which will be shown in Zapier UI
* I need to keep the underscore in dependencies, otherwise apify-shared-js will install newer underscore v0.13.* which cannot be bundled on Zapier platform.