### PR TITLE
feat: scrape single URL action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## 3.0.9 / 2023-08-29
 
 * The Run Actor action allows to run Actors from Apify Store.
+
 ## 3.0.4 / 2023-08-15
 
 ❗ Action Run Actor generates UI based on Input Schema if Actor has one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0 / 2023-10-09
+
+* Add action to Scrape single URL
+
 ## 3.0.9 / 2023-08-29
 
 * The Run Actor action allows to run Actors from Apify Store.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const actorsWithStoreTrigger = require('./src/triggers/actors_with_store');
 const getActorAdditionalFieldsTest = require('./src/triggers/actor_additional_fields');
 const taskRunCreate = require('./src/creates/task_run');
 const actorRunCreate = require('./src/creates/actor_run');
+const scrapeSingleUrlCreate = require('./src/creates/scrape_single_url');
 const setValueCreate = require('./src/creates/set_value');
 const taskLastRunSearch = require('./src/searches/task_last_run');
 const actorLastRunSearch = require('./src/searches/actor_last_run');
@@ -61,6 +62,7 @@ const App = {
         [taskRunCreate.key]: taskRunCreate,
         [actorRunCreate.key]: actorRunCreate,
         [setValueCreate.key]: setValueCreate,
+        [scrapeSingleUrlCreate.key]: scrapeSingleUrlCreate,
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.0.9",
+      "version": "3.1.0",
       "dependencies": {
         "@apify/consts": "^2.15.0",
         "@apify/utilities": "^2.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/consts.js
+++ b/src/consts.js
@@ -76,6 +76,73 @@ const ACTOR_RUN_SAMPLE = {
     },
 };
 
+const SCRAPE_SINGLE_URL_RUN_SAMPLE = {
+    id: 'HG7ML7M8z78YcAPEB',
+    actId: 'h3J7Uk3kMAmLCLRAh',
+    buildId: '7ML7M8zcAPEB78Y',
+    buildNumber: '0.1.15',
+    startedAt: '2015-11-30T07:34:24.202Z',
+    finishedAt: '2015-12-12T09:30:12.202Z',
+    status: 'SUCCEEDED',
+    exitCode: 0,
+    defaultKeyValueStoreId: 'sfAjeR4QmeJCQzTfe',
+    defaultDatasetId: '3ZojQDdFTsyE7Moy4',
+    defaultRequestQueueId: 'so93g2shcDzK3pA85',
+    containerUrl: 'https://rsklyfvj7pxp.runs.apify.net',
+    detailsPageUrl: 'https://console.apify.com/actors/$actId/runs/HG7ML7M8z78YcAPEB',
+    isStatusMessageTerminal: true,
+    statusMessage: 'Actor finished!',
+    usage: {
+        ACTOR_COMPUTE_UNITS: 0.0005676388888888888,
+        DATASET_READS: 0,
+        DATASET_WRITES: 0,
+        KEY_VALUE_STORE_READS: 2,
+        KEY_VALUE_STORE_WRITES: 2,
+        KEY_VALUE_STORE_LISTS: 0,
+        REQUEST_QUEUE_READS: 0,
+        REQUEST_QUEUE_WRITES: 0,
+        DATA_TRANSFER_INTERNAL_GBYTES: 0.0014107311144471169,
+        DATA_TRANSFER_EXTERNAL_GBYTES: 0,
+        PROXY_RESIDENTIAL_TRANSFER_GBYTES: 0,
+        PROXY_SERPS: 0,
+    },
+    usageTotalUsd: 0.0004075921112779114,
+    usageUsd: {
+        ACTOR_COMPUTE_UNITS: 0.00022705555555555554,
+        DATASET_READS: 0,
+        DATASET_WRITES: 0,
+        KEY_VALUE_STORE_READS: 0.00001,
+        KEY_VALUE_STORE_WRITES: 0.0001,
+        KEY_VALUE_STORE_LISTS: 0,
+        REQUEST_QUEUE_READS: 0,
+        REQUEST_QUEUE_WRITES: 0,
+        DATA_TRANSFER_INTERNAL_GBYTES: 0.00007053655572235585,
+        DATA_TRANSFER_EXTERNAL_GBYTES: 0,
+        PROXY_RESIDENTIAL_TRANSFER_GBYTES: 0,
+        PROXY_SERPS: 0,
+    },
+    pageUrl: 'https://www.example.com',
+    pageMetadata: {
+        canonicalUrl: 'https://example.com/',
+        title: 'Example Domain',
+        description: null,
+        author: null,
+        keywords: null,
+        languageCode: null,
+    },
+    pageContent: {
+        html: '<div id="readability-page-1" class="page"><div>\n    <h2>Example Domain</h2>\n    '
+            + '<p>This domain is for use in illustrative examples in documents. You may use this\n    '
+            + 'domain in literature without prior coordination or asking for permission.</p>\n    '
+            + '<p><a href="https://www.iana.org/domains/example">More information...</a></p>\n</div></div>',
+        markdown: '"## Example Domain\\n\\nThis domain is for use in illustrative examples in documents. '
+            + 'You may use this domain in literature without prior coordination or asking for permission.\\n\\n'
+            + '[More information...](https://www.iana.org/domains/example)"',
+        text: 'Example Domain\nThis domain is for use in illustrative examples in documents. '
+            + 'You may use this domain in literature without prior coordination or asking for permission.\nMore information...',
+    },
+};
+
 const ACTOR_RUN_OUTPUT_FIELDS = [
     { key: 'id', label: 'ID', type: 'string' },
     { key: 'actId', label: 'Actor ID', type: 'string' },
@@ -93,6 +160,29 @@ const ACTOR_RUN_OUTPUT_FIELDS = [
     { key: 'datasetItemsFileUrls', label: 'Dataset items file URLs', type: 'string' },
     { key: 'detailsPageUrl', label: 'Details page URL', type: 'string' },
     { key: 'containerUrl', label: 'Container URL', type: 'string' },
+];
+
+const SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS = [
+    { key: 'id', label: 'ID', type: 'string' },
+    { key: 'actId', label: 'Actor ID', type: 'string' },
+    { key: 'buildId', label: 'Build ID', type: 'string' },
+    { key: 'buildNumber', label: 'Build number', type: 'string' },
+    { key: 'startedAt', label: 'Started at' },
+    { key: 'finishedAt', label: 'Finished at' },
+    { key: 'status', label: 'Status', type: 'string' },
+    { key: 'exitCode', label: 'Exit Code', type: 'number' },
+    { key: 'defaultKeyValueStoreId', label: 'Default key-value store ID', type: 'string' },
+    { key: 'defaultDatasetId', label: 'Default dataset ID', type: 'string' },
+    { key: 'defaultRequestQueueId', label: 'Default request queue ID', type: 'string' },
+    { key: 'detailsPageUrl', label: 'Details page URL', type: 'string' },
+    { key: 'containerUrl', label: 'Container URL', type: 'string' },
+    { key: 'pageUrl', label: 'Page URL', type: 'string' },
+    { key: 'pageMetadata', label: 'Page metadata' },
+    { key: 'pageMetadata__title', label: 'Page title' },
+    { key: 'pageContent', label: 'Page content' },
+    { key: 'pageContent__html', label: 'Page HTML', type: 'string' },
+    { key: 'pageContent__markdown', label: 'Page markdown', type: 'string' },
+    { key: 'pageContent__text', label: 'Page text', type: 'string' },
 ];
 
 const TASK_RUN_SAMPLE = {
@@ -190,4 +280,6 @@ module.exports = {
     DATASET_SAMPLE,
     DATASET_OUTPUT_FIELDS,
     KEY_VALUE_STORE_SAMPLE,
+    SCRAPE_SINGLE_URL_RUN_SAMPLE,
+    SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS,
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -44,7 +44,7 @@ const ACTOR_RUN_SAMPLE = {
         xlsx: 'https://api.apify.com/v2/datasets/3ZojQDdFTsyE7Moy4/items?format=xlsx&clean=true&attachment=true',
     },
     containerUrl: 'https://rsklyfvj7pxp.runs.apify.net',
-    detailsPageUrl: 'https://console.apify.com/actors/$actId/runs/HG7ML7M8z78YcAPEB',
+    detailsPageUrl: 'https://console.apify.com/actors/h3J7Uk3kMAmLCLRAh/runs/HG7ML7M8z78YcAPEB',
     usage: {
         ACTOR_COMPUTE_UNITS: 0.0005676388888888888,
         DATASET_READS: 0,
@@ -89,7 +89,7 @@ const SCRAPE_SINGLE_URL_RUN_SAMPLE = {
     defaultDatasetId: '3ZojQDdFTsyE7Moy4',
     defaultRequestQueueId: 'so93g2shcDzK3pA85',
     containerUrl: 'https://rsklyfvj7pxp.runs.apify.net',
-    detailsPageUrl: 'https://console.apify.com/actors/$actId/runs/HG7ML7M8z78YcAPEB',
+    detailsPageUrl: 'https://console.apify.com/actors/h3J7Uk3kMAmLCLRAh/runs/HG7ML7M8z78YcAPEB',
     isStatusMessageTerminal: true,
     statusMessage: 'Actor finished!',
     usage: {

--- a/src/creates/scrape_single_url.js
+++ b/src/creates/scrape_single_url.js
@@ -1,0 +1,118 @@
+const _ = require('lodash');
+const {
+    APIFY_API_ENDPOINTS,
+    SCRAPE_SINGLE_URL_RUN_SAMPLE,
+    OMIT_ACTOR_RUN_FIELDS,
+    SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS,
+} = require('../consts');
+const { wrapRequestWithRetries } = require('../request_helpers');
+const { getDatasetItems } = require('../apify_helpers');
+
+const WEBSITE_CONTENT_CRAWLER_ACTOR_ID = 'aYG0l9s7dbB7j3gbS';
+
+const runWebsiteContentCrawler = async (z, bundle) => {
+    const { url, crawlerType } = bundle.inputData;
+
+    // We can use lower memory for Cheerio crawler, because it's not using browser.
+    const memory = crawlerType === 'cheerio' ? 1024 : 2048;
+
+    // NOTE: The Zap wait just 30 seconds for the run to finish.
+    const timeoutSecs = 60;
+
+    const input = {
+        startUrls: [{ url }],
+        crawlerType,
+        maxCrawlDepth: 0,
+        maxCrawlPages: 1,
+        maxResults: 1,
+        proxyConfiguration: {
+            useApifyProxy: true,
+        },
+        removeCookieWarnings: true,
+        saveHtml: true,
+        saveMarkdown: true,
+    };
+
+    const requestOpts = {
+        url: `${APIFY_API_ENDPOINTS.actors}/${WEBSITE_CONTENT_CRAWLER_ACTOR_ID}/runs`,
+        method: 'POST',
+        params: {
+            timeout: timeoutSecs,
+            memory,
+            waitForFinish: timeoutSecs,
+        },
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify(input),
+    };
+
+    const { data: run } = await wrapRequestWithRetries(z.request, requestOpts);
+
+    const { defaultDatasetId } = run;
+    // Attach Apify app URL to detail of run
+    run.detailsPageUrl = `https://console.apify.com/actors/${run.actId}/runs/${run.id}`;
+
+    if (defaultDatasetId) {
+        const datasetItems = await getDatasetItems(z, defaultDatasetId, { limit: 1 }, run.actId, true);
+        if (!datasetItems.items || datasetItems.items.length === 0) {
+            throw new Error('The data for the page content is missing, the page cannot be scraped or '
+            + `scraper did not finish in time. Please check ${run.detailsPageUrl} for more details.`);
+        }
+        run.pageUrl = datasetItems.items[0].url;
+        run.pageMetadata = datasetItems.items[0].metadata;
+        run.pageContent = {
+            html: datasetItems.items[0].html,
+            markdown: datasetItems.items[0].markdown,
+            text: datasetItems.items[0].text,
+        };
+    }
+
+    // Omit fields, which are useless for Zapier users.
+    return _.omit(run, OMIT_ACTOR_RUN_FIELDS);
+};
+
+module.exports = {
+    key: 'scrapeSingleUrl',
+    noun: 'Scrape Single URL',
+    display: {
+        label: 'Scrape Single URL',
+        description: 'Runs a scraper for website and returns its text content.',
+    },
+    operation: {
+        inputFields: [
+            {
+                label: 'URL',
+                helpText: 'The URL of the website to scrape.',
+                key: 'url',
+                required: true,
+                type: 'string',
+            },
+            {
+                label: 'Crawler type',
+                helpText: 'Select the crawler type: \n'
+                    + '- **Headless web browser** - Useful for modern websites with anti-scraping protections and JavaScript rendering. '
+                    + 'It recognizes common blocking patterns like CAPTCHAs and automatically retries blocked requests through new sessions. \n'
+                    + '- **Stealthy web browser** (default) - Another headless web browser with anti-blocking measures enabled. '
+                    + 'Try this if you encounter bot protection while scraping. \n'
+                    + '- **Raw HTTP client** - High-performance crawling mode that uses raw HTTP requests to fetch the pages. '
+                    + 'It is faster and cheaper, but it might not work on all websites.',
+                key: 'crawlerType',
+                required: true,
+                type: 'string',
+                choices: {
+                    'playwright:firefox': 'Headless browser (stealthy Firefox+Playwright) - '
+                        + 'Very reliable, best in avoiding blocking, but might be slow',
+                    'playwright:chrome': 'Headless browser (Chrome+Playwright) - Reliable, but might be slow',
+                    cheerio: 'Raw HTTP client (Cheerio) - Extremely fast, but cannot handle dynamic content',
+                },
+                default: 'playwright:firefox',
+            },
+        ],
+
+        perform: runWebsiteContentCrawler,
+
+        sample: SCRAPE_SINGLE_URL_RUN_SAMPLE,
+        outputFields: SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS,
+    },
+};

--- a/src/creates/scrape_single_url.js
+++ b/src/creates/scrape_single_url.js
@@ -77,10 +77,20 @@ module.exports = {
     noun: 'Scrape Single URL',
     display: {
         label: 'Scrape Single URL',
-        description: 'Runs a scraper for website and returns its text content.',
+        description: 'Runs a scraper for the website and returns its content as text, markdown and HTML. '
+            + 'This action is made for getting content of a single page, for example, to use in large language models (LLM) flows.',
     },
     operation: {
         inputFields: [
+            {
+                label: 'Note',
+                key: 'note',
+                type: 'copy',
+                helpText: 'This action is made to get content on a single page. Under the hood, '
+                    + 'it uses [Website Content Scraper](https://apify.com/apify/website-content-crawler). '
+                    + 'You can run Website Content Scraper or Web Scraper, which have various options to help '
+                    + 'you with anti scraping protection or scraping multiple URLs using "Run Actor" action.',
+            },
             {
                 label: 'URL',
                 helpText: 'The URL of the website to scrape.',

--- a/src/creates/scrape_single_url.js
+++ b/src/creates/scrape_single_url.js
@@ -88,9 +88,9 @@ module.exports = {
                 key: 'note',
                 type: 'copy',
                 helpText: 'This action is designed to scrape the content of a single web page. '
-                    + 'Behind the scenes, it utilizes the [Website Content Crawler](https://apify.com/apify/website-content-crawler). '
-                    + 'You can choose to run either the [Website Content Crawler](https://apify.com/apify/website-content-crawler) or '
-                    + 'the [Web Scraper](https://apify.com/apify/web-scraper), '
+                    + 'Behind the scenes, it utilizes [Website Content Crawler](https://apify.com/apify/website-content-crawler). '
+                    + 'You can choose to run either [Website Content Crawler](https://apify.com/apify/website-content-crawler) or '
+                    + '[Web Scraper](https://apify.com/apify/web-scraper), '
                     + 'both of which offer a range of options to assist you in dealing with anti-scraping or '
                     + 'scraping multiple URLs and many more. These scrapers are available to run under "Run Actor" in Apify Zaps.',
             },
@@ -106,7 +106,7 @@ module.exports = {
                 helpText: '- **Headless web browser** - Useful for modern websites with anti-scraping protections and JavaScript rendering. '
                     + 'It recognizes common blocking patterns like CAPTCHAs and automatically retries blocked requests through new sessions. \n'
                     + '- **Stealthy web browser** (default) - Another headless web browser with anti-blocking measures enabled. '
-                    + 'Try this if you encounter bot protection while scraping. \n'
+                    + 'Try this if you encounter anti-bot protections while scraping. \n'
                     + '- **Raw HTTP client** - High-performance crawling mode that uses raw HTTP requests to fetch the pages. '
                     + 'It is faster and cheaper, but it might not work on all websites.',
                 key: 'crawlerType',
@@ -114,7 +114,7 @@ module.exports = {
                 type: 'string',
                 choices: {
                     'playwright:firefox': 'Headless browser (stealthy Firefox+Playwright) - '
-                        + 'Very reliable, best in avoiding blocking, but might be slow',
+                        + 'Very reliable. Great for avoiding blocking, but it might be slow',
                     'playwright:chrome': 'Headless browser (Chrome+Playwright) - Reliable, but might be slow',
                     cheerio: 'Raw HTTP client (Cheerio) - Extremely fast, but cannot handle dynamic content',
                 },

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai');
+const zapier = require('zapier-platform-core');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const { TEST_USER_TOKEN, apifyClient } = require('../helpers');
+const App = require('../../index');
+const { SCRAPE_SINGLE_URL_RUN_SAMPLE } = require('../../src/consts');
+
+const appTester = zapier.createAppTester(App);
+
+chai.use(chaiAsPromised);
+
+describe('scrape single URL', () => {
+    it('runs scrape single URL with correct output fields', async () => {
+        const options = {
+            url: 'https://www.example.com',
+            crawlerType: 'cheerio',
+        };
+        const bundle = {
+            authData: {
+                token: TEST_USER_TOKEN,
+            },
+            inputData: options,
+        };
+
+        const testResult = await appTester(App.creates.scrapeSingleUrl.operation.perform, bundle);
+        const scrapeSingleUrlRun = await apifyClient.run(testResult.id).get();
+        const datasetClient = await apifyClient.dataset(scrapeSingleUrlRun.defaultDatasetId);
+        const datasetItems = await datasetClient.listItems({ limit: 1 });
+        const kvsClient = await apifyClient.keyValueStore(scrapeSingleUrlRun.defaultKeyValueStoreId);
+        const input = await kvsClient.getRecord('INPUT');
+
+        expect(testResult).to.have.all.keys(Object.keys(SCRAPE_SINGLE_URL_RUN_SAMPLE));
+        expect(scrapeSingleUrlRun.status).to.be.eql('SUCCEEDED');
+        // Run scraper just one single URL
+        expect(datasetItems.items.length).to.be.eql(1);
+
+        // Correctly set type of crawler
+        expect(input.value.crawlerType).to.be.eql(options.crawlerType);
+
+        // Check that output fields are correct
+        const result = datasetItems.items[0];
+        expect(testResult.pageUrl).to.be.eql(result.url);
+        expect(testResult.pageContent).to.be.eql({
+            html: result.html,
+            markdown: result.markdown,
+            text: result.text,
+        });
+        expect(testResult.pageMetadata).to.be.eql(result.metadata);
+    }).timeout(60000);
+
+    it('throws if there are no data', async () => {
+        const options = {
+            url: 'https://www.zz-this-page-doesn-not-exists-xx.com',
+            crawlerType: 'cheerio',
+        };
+        const bundle = {
+            authData: {
+                token: TEST_USER_TOKEN,
+            },
+            inputData: options,
+        };
+        await expect(appTester(App.creates.scrapeSingleUrl.operation.perform, bundle)).to.be.rejectedWith(/page content is missing/);
+    }).timeout(65000);
+});


### PR DESCRIPTION
Adding new action to run Scrape single URL, the action is using Website Content Crawler under hood.

You can test the new action under 3.1.0 version in Zapier
![image](https://github.com/apify/apify-zapier-integration/assets/11837643/ba929d19-5cd2-4156-9dc6-9c7180b5f0f0)

see [Testing in Zapier section in previous PR ](https://github.com/apify/apify-zapier-integration/pull/37)
