### PR TITLE
fix: Fix falsy values were skipped in actor run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1 / 2023-11-14
+
+* Fix falsy values in Actor run action
+
 ## 3.1.0 / 2023-10-09
 
 * Add action to Scrape single URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@apify/consts": "^2.15.0",
         "@apify/utilities": "^2.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/creates/actor_run.js
+++ b/src/creates/actor_run.js
@@ -47,7 +47,7 @@ const runActor = async (z, bundle) => {
             inputSchemaKeys.forEach((key) => {
                 const fieldKey = prefixInputFieldKey(key);
                 const value = bundle.inputData[fieldKey];
-                if (value) {
+                if (value !== undefined) { // NOTE: value can be false or 0, these are legit value.
                     const { editor, title } = inputSchema.properties[key];
                     if (editor === 'datepicker') {
                         const date = dayjs(value);

--- a/src/creates/actor_run.js
+++ b/src/creates/actor_run.js
@@ -47,7 +47,7 @@ const runActor = async (z, bundle) => {
             inputSchemaKeys.forEach((key) => {
                 const fieldKey = prefixInputFieldKey(key);
                 const value = bundle.inputData[fieldKey];
-                if (value !== undefined) { // NOTE: value can be false or 0, these are legit value.
+                if (value !== undefined && value !== null) { // NOTE: value can be false or 0, these are legit value.
                     const { editor, title } = inputSchema.properties[key];
                     if (editor === 'datepicker') {
                         const date = dayjs(value);


### PR DESCRIPTION
When the user set a false or 0 value we skipped it, because wrong condition.