### PR TITLE
feat: Adding output fields for dataset items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0 / 2024-11-23
+
+* Improve output fields for all actions where dataset is included
+* Updated packages
+
+
 ## 3.1.1 / 2023-11-14
 
 * Fix falsy values in Actor run action

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const actorRunFinishedTrigger = require('./src/triggers/actor_run_finished');
 const actorsTrigger = require('./src/triggers/actors');
 const actorsWithStoreTrigger = require('./src/triggers/actors_with_store');
 const getActorAdditionalFieldsTest = require('./src/triggers/actor_additional_fields');
+const getDatasetOutputFieldsTest = require('./src/triggers/dataset_additional_output_fields');
 const taskRunCreate = require('./src/creates/task_run');
 const actorRunCreate = require('./src/creates/actor_run');
 const scrapeSingleUrlCreate = require('./src/creates/scrape_single_url');
@@ -46,6 +47,7 @@ const App = {
         [actorRunFinishedTrigger.key]: actorRunFinishedTrigger,
         [actorsTrigger.key]: actorsTrigger,
         [getActorAdditionalFieldsTest.key]: getActorAdditionalFieldsTest,
+        [getDatasetOutputFieldsTest.key]: getDatasetOutputFieldsTest,
         [actorsWithStoreTrigger.key]: actorsWithStoreTrigger,
     },
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const actorRunFinishedTrigger = require('./src/triggers/actor_run_finished');
 const actorsTrigger = require('./src/triggers/actors');
 const actorsWithStoreTrigger = require('./src/triggers/actors_with_store');
 const getActorAdditionalFieldsTest = require('./src/triggers/actor_additional_fields');
-const getDatasetOutputFieldsTest = require('./src/triggers/dataset_additional_output_fields');
+const getActorDatasetOutputFieldsTest = require('./src/triggers/actor_dataset_additional_output_fields');
 const taskRunCreate = require('./src/creates/task_run');
 const actorRunCreate = require('./src/creates/actor_run');
 const scrapeSingleUrlCreate = require('./src/creates/scrape_single_url');
@@ -47,7 +47,7 @@ const App = {
         [actorRunFinishedTrigger.key]: actorRunFinishedTrigger,
         [actorsTrigger.key]: actorsTrigger,
         [getActorAdditionalFieldsTest.key]: getActorAdditionalFieldsTest,
-        [getDatasetOutputFieldsTest.key]: getDatasetOutputFieldsTest,
+        [getActorDatasetOutputFieldsTest.key]: getActorDatasetOutputFieldsTest,
         [actorsWithStoreTrigger.key]: actorsWithStoreTrigger,
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "@apify/consts": "^2.29.0",
         "@apify/utilities": "^2.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "dependencies": {
         "@apify/consts": "^2.29.0",
         "@apify/utilities": "^2.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -130,7 +130,7 @@ const enrichActorRun = async (z, run, storeKeysToInclude = []) => {
 };
 
 // Process to subscribe to Apify webhook
-const subscribeWebkook = async (z, bundle, condition) => {
+const subscribeWebhook = async (z, bundle, condition) => {
     const webhookOpts = {
         eventTypes: WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL,
         condition,
@@ -534,7 +534,7 @@ const printPrettyActorOrTaskName = (actorOrTask) => {
 
 module.exports = {
     enrichActorRun,
-    subscribeWebkook,
+    subscribeWebhook,
     unsubscribeWebhook,
     getActorRun,
     getOrCreateKeyValueStore,

--- a/src/consts.js
+++ b/src/consts.js
@@ -158,9 +158,10 @@ const ACTOR_RUN_OUTPUT_FIELDS = [
     { key: 'OUTPUT', label: 'Output' },
     { key: 'detailsPageUrl', label: 'Details page URL', type: 'string' },
     { key: 'containerUrl', label: 'Container URL', type: 'string' },
-    // TODO: Remove
-    // { key: 'datasetItems', label: 'Dataset items' },
-    // { key: 'datasetItemsFileUrls', label: 'Dataset items file URLs', type: 'string' },
+    { key: 'datasetItemsFileUrls__xml', label: 'Dataset items XML file URL', type: 'string' },
+    { key: 'datasetItemsFileUrls__csv', label: 'Dataset items CSV file URL', type: 'string' },
+    { key: 'datasetItemsFileUrls__json', label: 'Dataset items JSON file URL', type: 'string' },
+    { key: 'datasetItemsFileUrls__xlsx', label: 'Dataset items Excel file URL', type: 'string' },
 ];
 
 const SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS = [
@@ -221,8 +222,11 @@ const DATASET_OUTPUT_FIELDS = [
     { key: 'cleanItemCount', label: 'Clean item count', type: 'integer' },
     { key: 'actId', label: 'Actor ID', type: 'string' },
     { key: 'actRunId', label: 'Actor run ID', type: 'string' },
-    { key: 'items', label: 'Items' },
     { key: 'itemsFileUrls', label: 'Items file URLs', type: 'string' },
+    { key: 'itemsFileUrls_xml', label: 'Items XML file URL', type: 'string' },
+    { key: 'itemsFileUrls_csv', label: 'Items CSV file URL', type: 'string' },
+    { key: 'itemsFileUrls_json', label: 'Items JSON file URL', type: 'string' },
+    { key: 'itemsFileUrls_xlsx', label: 'Items Excel file URL', type: 'string' },
 ];
 
 /**

--- a/src/consts.js
+++ b/src/consts.js
@@ -156,10 +156,11 @@ const ACTOR_RUN_OUTPUT_FIELDS = [
     { key: 'defaultDatasetId', label: 'Default dataset ID', type: 'string' },
     { key: 'defaultRequestQueueId', label: 'Default request queue ID', type: 'string' },
     { key: 'OUTPUT', label: 'Output' },
-    { key: 'datasetItems', label: 'Dataset items' },
-    { key: 'datasetItemsFileUrls', label: 'Dataset items file URLs', type: 'string' },
     { key: 'detailsPageUrl', label: 'Details page URL', type: 'string' },
     { key: 'containerUrl', label: 'Container URL', type: 'string' },
+    // TODO: Remove
+    // { key: 'datasetItems', label: 'Dataset items' },
+    // { key: 'datasetItemsFileUrls', label: 'Dataset items file URLs', type: 'string' },
 ];
 
 const SCRAPE_SINGLE_URL_RUN_OUTPUT_FIELDS = [

--- a/src/consts.js
+++ b/src/consts.js
@@ -222,11 +222,10 @@ const DATASET_OUTPUT_FIELDS = [
     { key: 'cleanItemCount', label: 'Clean item count', type: 'integer' },
     { key: 'actId', label: 'Actor ID', type: 'string' },
     { key: 'actRunId', label: 'Actor run ID', type: 'string' },
-    { key: 'itemsFileUrls', label: 'Items file URLs', type: 'string' },
-    { key: 'itemsFileUrls_xml', label: 'Items XML file URL', type: 'string' },
-    { key: 'itemsFileUrls_csv', label: 'Items CSV file URL', type: 'string' },
-    { key: 'itemsFileUrls_json', label: 'Items JSON file URL', type: 'string' },
-    { key: 'itemsFileUrls_xlsx', label: 'Items Excel file URL', type: 'string' },
+    { key: 'itemsFileUrls__xml', label: 'Items XML file URL', type: 'string' },
+    { key: 'itemsFileUrls__csv', label: 'Items CSV file URL', type: 'string' },
+    { key: 'itemsFileUrls__json', label: 'Items JSON file URL', type: 'string' },
+    { key: 'itemsFileUrls__xlsx', label: 'Items Excel file URL', type: 'string' },
 ];
 
 /**

--- a/src/creates/actor_run.js
+++ b/src/creates/actor_run.js
@@ -7,6 +7,7 @@ const {
     prefixInputFieldKey,
 } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getDatasetOutputFields } = require('../output_fields');
 
 const runActor = async (z, bundle) => {
     const { actorId, runSync, inputBody, inputContentType, build, timeoutSecs, memoryMbytes } = bundle.inputData;
@@ -123,6 +124,9 @@ module.exports = {
         perform: runActor,
 
         sample: ACTOR_RUN_SAMPLE,
-        outputFields: ACTOR_RUN_OUTPUT_FIELDS,
+        outputFields: [
+            ...ACTOR_RUN_OUTPUT_FIELDS,
+            getDatasetOutputFields,
+        ],
     },
 };

--- a/src/creates/actor_run.js
+++ b/src/creates/actor_run.js
@@ -7,7 +7,7 @@ const {
     prefixInputFieldKey,
 } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
-const { getDatasetOutputFields } = require('../output_fields');
+const { getActorDatasetOutputFields } = require('../output_fields');
 
 const runActor = async (z, bundle) => {
     const { actorId, runSync, inputBody, inputContentType, build, timeoutSecs, memoryMbytes } = bundle.inputData;
@@ -126,7 +126,7 @@ module.exports = {
         sample: ACTOR_RUN_SAMPLE,
         outputFields: [
             ...ACTOR_RUN_OUTPUT_FIELDS,
-            getDatasetOutputFields,
+            getActorDatasetOutputFields,
         ],
     },
 };

--- a/src/creates/task_run.js
+++ b/src/creates/task_run.js
@@ -1,6 +1,7 @@
 const { APIFY_API_ENDPOINTS, TASK_RUN_SAMPLE, TASK_RUN_OUTPUT_FIELDS } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getTaskDatasetOutputFields } = require('../output_fields');
 
 const RAW_INPUT_LABEL = 'Input JSON overrides';
 
@@ -85,6 +86,9 @@ module.exports = {
         perform: runTask,
 
         sample: TASK_RUN_SAMPLE,
-        outputFields: TASK_RUN_OUTPUT_FIELDS,
+        outputFields: [
+            ...TASK_RUN_OUTPUT_FIELDS,
+            getTaskDatasetOutputFields,
+        ],
     },
 };

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -10,7 +10,7 @@ const { convertPlainObjectToFieldSchema } = require('./zapier_helpers');
  * @param {string} datasetId
  * @returns {Promise<*[]>}
  */
-const getDatasetItemsOutputFields = async (z, datasetId, actorId) => {
+const getDatasetItemsOutputFields = async (z, datasetId, actorId, keyPrefix = 'datasetItems[]') => {
     let datasetItems;
     try {
         datasetItems = await getDatasetItems(z, datasetId, {
@@ -27,7 +27,7 @@ const getDatasetItemsOutputFields = async (z, datasetId, actorId) => {
     if (items.length === 0) return [];
     // NOTE: We are using the first 10 items to generate output fields to cover most of the cases.
     const mergedItem = _.merge({}, ...items);
-    return convertPlainObjectToFieldSchema(mergedItem, 'datasetItems');
+    return convertPlainObjectToFieldSchema(mergedItem, keyPrefix);
 };
 
 const getDatasetOutputFields = async (z, bundle) => {

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -1,0 +1,58 @@
+const _ = require('lodash');
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
+const { getDatasetItems } = require('./apify_helpers');
+const { wrapRequestWithRetries } = require('./request_helpers');
+const { APIFY_API_ENDPOINTS } = require('./consts');
+const { convertPlainObjectToFieldSchema } = require('./zapier_helpers');
+
+/**
+ * Transforms object items to output fields.
+ * @param {string} datasetId
+ * @returns {Promise<*[]>}
+ */
+const getDatasetItemsOutputFields = async (z, datasetId, actorId) => {
+    let datasetItems;
+    try {
+        datasetItems = await getDatasetItems(z, datasetId, {
+            limit: 10,
+        }, actorId);
+    } catch (err) {
+        z.console.error('Error while fetching dataset items', err);
+        // Return default output fields, if there is no successful run yet or any other error.
+        return [];
+    }
+
+    const { items } = datasetItems;
+    // If there are no items, return default output fields.
+    if (items.length === 0) return [];
+    // NOTE: We are using the first 10 items to generate output fields to cover most of the cases.
+    const mergedItem = _.merge({}, ...items);
+    return convertPlainObjectToFieldSchema(mergedItem, 'datasetItems');
+};
+
+const getDatasetOutputFields = async (z, bundle) => {
+    const { actorId } = bundle.inputData;
+    let lastSuccessDatasetItems;
+    try {
+        lastSuccessDatasetItems = await wrapRequestWithRetries(z.request, {
+            url: `${APIFY_API_ENDPOINTS.actors}/${actorId}/runs/last`,
+            params: {
+                status: ACTOR_JOB_STATUSES.SUCCEEDED,
+            },
+        });
+    } catch (err) {
+        // 404 status = There is not successful run yet.
+        if (err.status !== 404) {
+            z.console.error('Error while fetching dataset items', err);
+        }
+        // Return default output fields, if there is no successful run yet or any other error.
+        return [];
+    }
+    const { data: run } = lastSuccessDatasetItems;
+    return getDatasetItemsOutputFields(z, run.defaultDatasetId, actorId);
+};
+
+module.exports = {
+    getDatasetItemsOutputFields,
+    getDatasetOutputFields,
+};

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -6,7 +6,7 @@ const { APIFY_API_ENDPOINTS } = require('./consts');
 const { convertPlainObjectToFieldSchema } = require('./zapier_helpers');
 
 /**
- * Transforms object items to output fields.
+ * Download items from dataset and create FieldSchema out of them.
  * @param {string} datasetId
  * @returns {Promise<*[]>}
  */

--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -2,6 +2,7 @@ const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { ACTOR_RUN_SAMPLE, ACTOR_RUN_OUTPUT_FIELDS, APIFY_API_ENDPOINTS } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getDatasetOutputFields } = require('../output_fields');
 
 const getLastActorRun = async (z, bundle) => {
     const { actorId, status } = bundle.inputData;
@@ -51,6 +52,9 @@ module.exports = {
         perform: getLastActorRun,
 
         sample: ACTOR_RUN_SAMPLE,
-        outputFields: ACTOR_RUN_OUTPUT_FIELDS,
+        outputFields: [
+            ...ACTOR_RUN_OUTPUT_FIELDS,
+            getDatasetOutputFields,
+        ],
     },
 };

--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -2,7 +2,7 @@ const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { ACTOR_RUN_SAMPLE, ACTOR_RUN_OUTPUT_FIELDS, APIFY_API_ENDPOINTS } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
-const { getDatasetOutputFields } = require('../output_fields');
+const { getActorDatasetOutputFields } = require('../output_fields');
 
 const getLastActorRun = async (z, bundle) => {
     const { actorId, status } = bundle.inputData;
@@ -54,7 +54,7 @@ module.exports = {
         sample: ACTOR_RUN_SAMPLE,
         outputFields: [
             ...ACTOR_RUN_OUTPUT_FIELDS,
-            getDatasetOutputFields,
+            getActorDatasetOutputFields,
         ],
     },
 };

--- a/src/searches/task_last_run.js
+++ b/src/searches/task_last_run.js
@@ -2,6 +2,7 @@ const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { TASK_RUN_SAMPLE, TASK_RUN_OUTPUT_FIELDS, APIFY_API_ENDPOINTS } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getTaskDatasetOutputFields } = require('../output_fields');
 
 const getLastTaskRun = async (z, bundle) => {
     const { taskId, status } = bundle.inputData;
@@ -53,6 +54,9 @@ module.exports = {
         perform: getLastTaskRun,
 
         sample: TASK_RUN_SAMPLE,
-        outputFields: TASK_RUN_OUTPUT_FIELDS,
+        outputFields: [
+            ...TASK_RUN_OUTPUT_FIELDS,
+            getTaskDatasetOutputFields,
+        ],
     },
 };

--- a/src/triggers/actor_dataset_additional_output_fields.js
+++ b/src/triggers/actor_dataset_additional_output_fields.js
@@ -1,20 +1,20 @@
-const { getDatasetOutputFields } = require('../output_fields');
+const { getActorDatasetOutputFields } = require('../output_fields');
 
 /**
- * This is hidden trigger is used to test getDatasetOutputFields function.
+ * This is hidden trigger is used to test getActorDatasetOutputFields function.
  * It is only way how to test function like that in Zapier context,
  * check my issue https://github.com/zapier/zapier-platform-cli/issues/418
  */
 module.exports = {
-    key: 'getDatasetOutputFieldsTest',
+    key: 'getActorDatasetOutputFieldsTest',
     noun: 'Dataset Output Additional Fields',
     display: {
         label: 'Dataset Output Additional Fields',
-        description: 'This is a hidden trigger used to test getDatasetOutputFields function.',
+        description: 'This is a hidden trigger used to test getActorDatasetOutputFields function.',
         hidden: true,
     },
     operation: {
         // since this is a "hidden" trigger, there aren't any inputFields needed
-        perform: getDatasetOutputFields,
+        perform: getActorDatasetOutputFields,
     },
 };

--- a/src/triggers/actor_run_finished.js
+++ b/src/triggers/actor_run_finished.js
@@ -1,7 +1,8 @@
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
-const { APIFY_API_ENDPOINTS, TASK_RUN_SAMPLE, TASK_RUN_OUTPUT_FIELDS } = require('../consts');
-const { enrichActorRun, subscribeWebkook, unsubscribeWebhook, getActorRun } = require('../apify_helpers');
+const { APIFY_API_ENDPOINTS, ACTOR_RUN_SAMPLE, ACTOR_RUN_OUTPUT_FIELDS } = require('../consts');
+const { enrichActorRun, subscribeWebhook, unsubscribeWebhook, getActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getActorDatasetOutputFields } = require('../output_fields');
 
 const getFallbackActorRuns = async (z, bundle) => {
     const response = await wrapRequestWithRetries(z.request, {
@@ -41,14 +42,17 @@ module.exports = {
             },
         ],
         type: 'hook',
-        performSubscribe: (z, bundle) => subscribeWebkook(z, bundle, { actorId: bundle.inputData.actorId }),
+        performSubscribe: (z, bundle) => subscribeWebhook(z, bundle, { actorId: bundle.inputData.actorId }),
         performUnsubscribe: unsubscribeWebhook,
         // Perform is called after each hit to the webhook API
         perform: getActorRun,
         // PerformList is used to get testing data for users in Zapier app
         performList: getFallbackActorRuns,
         // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
-        sample: TASK_RUN_SAMPLE,
-        outputFields: TASK_RUN_OUTPUT_FIELDS,
+        sample: ACTOR_RUN_SAMPLE,
+        outputFields: [
+            ...ACTOR_RUN_OUTPUT_FIELDS,
+            getActorDatasetOutputFields,
+        ],
     },
 };

--- a/src/triggers/dataset_additional_output_fields.js
+++ b/src/triggers/dataset_additional_output_fields.js
@@ -1,0 +1,20 @@
+const { getDatasetOutputFields } = require('../output_fields');
+
+/**
+ * This is hidden trigger is used to test getDatasetOutputFields function.
+ * It is only way how to test function like that in Zapier context,
+ * check my issue https://github.com/zapier/zapier-platform-cli/issues/418
+ */
+module.exports = {
+    key: 'getDatasetOutputFieldsTest',
+    noun: 'Dataset Output Additional Fields',
+    display: {
+        label: 'Dataset Output Additional Fields',
+        description: 'This is a hidden trigger used to test getDatasetOutputFields function.',
+        hidden: true,
+    },
+    operation: {
+        // since this is a "hidden" trigger, there aren't any inputFields needed
+        perform: getDatasetOutputFields,
+    },
+};

--- a/src/triggers/task_run_finished.js
+++ b/src/triggers/task_run_finished.js
@@ -1,7 +1,8 @@
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { APIFY_API_ENDPOINTS, TASK_RUN_SAMPLE, TASK_RUN_OUTPUT_FIELDS } = require('../consts');
-const { enrichActorRun, subscribeWebkook, unsubscribeWebhook, getActorRun } = require('../apify_helpers');
+const { enrichActorRun, subscribeWebhook, unsubscribeWebhook, getActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+const { getTaskDatasetOutputFields } = require('../output_fields');
 
 const getFallbackTaskActorRuns = async (z, bundle) => {
     const response = await wrapRequestWithRetries(z.request, {
@@ -46,11 +47,14 @@ module.exports = {
             },
         ],
         type: 'hook',
-        performSubscribe: (z, bundle) => subscribeWebkook(z, bundle, { actorTaskId: bundle.inputData.taskId }),
+        performSubscribe: (z, bundle) => subscribeWebhook(z, bundle, { actorTaskId: bundle.inputData.taskId }),
         performUnsubscribe: unsubscribeWebhook,
         perform: getActorRun,
         performList: getFallbackTaskActorRuns,
         sample: TASK_RUN_SAMPLE,
-        outputFields: TASK_RUN_OUTPUT_FIELDS,
+        outputFields: [
+            ...TASK_RUN_OUTPUT_FIELDS,
+            getTaskDatasetOutputFields,
+        ],
     },
 };

--- a/src/zapier_helpers.js
+++ b/src/zapier_helpers.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const dayjs = require('dayjs');
 /**
- * Converts a plain object to an array of field schema objects.
+ * Converts a plain object to an array of FieldSchema objects.
+ * https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema
  * @param object
  * @param keyPrefix
  * @returns {*[]}

--- a/src/zapier_helpers.js
+++ b/src/zapier_helpers.js
@@ -1,0 +1,48 @@
+const _ = require('lodash');
+const dayjs = require('dayjs');
+/**
+ * Converts a plain object to an array of field schema objects.
+ * @param object
+ * @param keyPrefix
+ * @returns {*[]}
+ */
+const convertPlainObjectToFieldSchema = (object, keyPrefix = '') => {
+    if (!_.isPlainObject(object)) return [];
+
+    const fieldSchema = [];
+
+    Object.entries(object).forEach(([key, value]) => {
+        const fullKey = keyPrefix ? `${keyPrefix}${key}` : key;
+
+        if (_.isString(value)) {
+            fieldSchema.push({ key: fullKey, type: dayjs(value).isValid() ? 'datetime' : 'string' });
+        } else if (_.isNumber(value)) {
+            fieldSchema.push({ key: fullKey, type: 'number' });
+        } else if (_.isBoolean(value)) {
+            fieldSchema.push({ key: fullKey, type: 'boolean' });
+        } else if (_.isArray(value)) {
+            // Process array elements. If array contains objects, use keys with []
+            if (_.isPlainObject(value[0])) {
+                fieldSchema.push(...convertPlainObjectToFieldSchema(value[0], `${fullKey}[]`));
+            } else {
+                // Array of primitives or datetime
+                const type = _.isString(value[0]) && dayjs(value[0]).isValid()
+                    ? 'datetime'
+                    : typeof value[0];
+                fieldSchema.push({ key: fullKey, type, list: true });
+            }
+        } else if (_.isPlainObject(value)) {
+            // For nested objects, recursively process fields
+            fieldSchema.push(...convertPlainObjectToFieldSchema(value, `${fullKey}__`));
+        } else {
+            // Any other object, null and possibly undefined.
+            fieldSchema.push({ key: fullKey });
+        }
+    });
+
+    return fieldSchema;
+};
+
+module.exports = {
+    convertPlainObjectToFieldSchema,
+};

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -173,8 +173,8 @@ describe('create actor run', () => {
         // Run an Actor, the output items will be generated based on latest success run
         await apifyClient.actor(testActorId).call({
             datasetItems: items,
-        });
-        const fields = await appTester(App.triggers.getDatasetOutputFieldsTest.operation.perform, bundle);
+        }, { build: 'latest' });
+        const fields = await appTester(App.triggers.getActorDatasetOutputFieldsTest.operation.perform, bundle);
         expect(fields).to.be.eql([
             { key: 'datasetItems[]a', type: 'number' },
             { key: 'datasetItems[]b', type: 'number' },

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -170,12 +170,23 @@ describe('create actor run', () => {
             { a: 4, b: 5, f: new Date() },
             { a: 4, b: 5, g: ['a', 'b'], h: [{ a: 1, b: 2 }] },
         ];
-        const run = await apifyClient.actor(testActorId).call({
+        // Run an Actor, the output items will be generated based on latest success run
+        await apifyClient.actor(testActorId).call({
             datasetItems: items,
         });
-        console.log(run);
         const fields = await appTester(App.triggers.getDatasetOutputFieldsTest.operation.perform, bundle);
-        console.log(fields);
+        expect(fields).to.be.eql([
+            { key: 'datasetItems[]a', type: 'number' },
+            { key: 'datasetItems[]b', type: 'number' },
+            { key: 'datasetItems[]c', type: 'string' },
+            { key: 'datasetItems[]d', type: 'string' },
+            { key: 'datasetItems[]e__a', type: 'number' },
+            { key: 'datasetItems[]e__b', type: 'number' },
+            { key: 'datasetItems[]f', type: 'datetime' },
+            { key: 'datasetItems[]g', type: 'string', list: true },
+            { key: 'datasetItems[]h[]a', type: 'number' },
+            { key: 'datasetItems[]h[]b', type: 'number' },
+        ]);
     }).timeout(120000);
 
     it('runSync work', async () => {

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -44,7 +44,7 @@ describe('create task run', () => {
 
         const testResult = await appTester(App.creates.createTaskRun.operation.perform, bundle);
 
-        expect(testResult).to.have.all.keys(Object.keys(TASK_RUN_SAMPLE).concat(['isStatusMessageTerminal', 'statusMessage']));
+        expect(testResult).to.have.any.keys(Object.keys(TASK_RUN_SAMPLE).concat(['isStatusMessageTerminal', 'statusMessage']));
         expect(testResult.status).to.be.eql('SUCCEEDED');
         expect(testResult.OUTPUT).to.not.equal(null);
         expect(testResult.datasetItems.length).to.be.at.least(1);

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -71,7 +71,11 @@ const createAndBuildActor = async () => {
     Apify.main(async (context) => {
         const input = await Apify.getInput();
         console.log('It works.');
-        await Apify.pushData({ foo: 'bar' });
+        if (input && input.datasetItems) {
+            await Apify.pushData(input.datasetItems);
+        } else {
+            await Apify.pushData({ foo: 'bar' });
+        }
         if (input && input.outputRandomFile) {
             await Apify.setValue('OUTPUT', 'blabla', { contentType: 'text/plain' });
         } else {

--- a/test/zapier_helpers.js
+++ b/test/zapier_helpers.js
@@ -1,0 +1,44 @@
+const { expect } = require('chai');
+const { convertPlainObjectToFieldSchema } = require('../src/zapier_helpers');
+
+describe('zapier helpers', () => {
+    it('convertToFieldSchema works', () => {
+        const object = {
+            a: 'string',
+            b: 1,
+            c: true,
+            d: [1, 2, 3],
+            e: { key: 'value', key2: 'value2' },
+            f: '2021-01-01T00:00:00Z',
+            g: [{ key: 'value', key2: 1 }, { key: 'value' }],
+            h: { key: { keyChild: 'value', keyChildArray: [{ key: 'value' }] } },
+        };
+        const outputFields = convertPlainObjectToFieldSchema(object);
+        const expected = [
+            { key: 'a', type: 'string' },
+            { key: 'b', type: 'number' },
+            { key: 'c', type: 'boolean' },
+            { key: 'd', type: 'number', list: true },
+            { key: 'e__key', type: 'string' },
+            { key: 'e__key2', type: 'string' },
+            { key: 'f', type: 'datetime' },
+            { key: 'g[]key', type: 'string' },
+            { key: 'g[]key2', type: 'number' },
+            { key: 'h__key__keyChild', type: 'string' },
+            { key: 'h__key__keyChildArray[]key', type: 'string' },
+        ];
+        expect(outputFields).to.be.eql(expected);
+    });
+
+    it('convertToFieldSchema works with empty object', () => {
+        const object = {};
+        convertPlainObjectToFieldSchema(object);
+        expect(convertPlainObjectToFieldSchema(object)).to.be.eql([]);
+    });
+
+    it('convertToFieldSchema works with null object', () => {
+        const object = null;
+        convertPlainObjectToFieldSchema(object);
+        expect(convertPlainObjectToFieldSchema(object)).to.be.eql([]);
+    });
+});


### PR DESCRIPTION
In this PR we are adding dynamic outputFields for the action which returns datset items. This requires parsing JavaScript plain object into FieldsShema, the definition of schema is [here](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldsschema), this is also part of this PR.

Why we need this:
When user connect Apify into some Zapier flow the output data from Actor run dataset items cannot be easily mapped into next flow, the reason was that we are missing the dataset items into outputFields. See the problem users face - here is [reported issue](https://developer.zapier.com/app/15018/issues/13).
By adding dataset items into outputFields we solve this and the user can easily map the dataset data between Zapier flows.

## How to test on Zapier platform
The new version is in preview mode. You need to be part of the Apify developers group on Zapier; I added you.
Then you will see the Apify version when you want to create the Zap, the tested version is **3.2.0**.
<img width="668" alt="image" src="https://github.com/user-attachments/assets/1257685d-3114-46aa-9cf0-9fb020c4f7fe">


fixes #48