### PR TITLE
feat: OAuth2 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.10 / 2025-04-29
+* Authentication with Apify is now possible only via OAuth2
+
 ## 3.2.1 / 2024-11-23
 
 * Updated packages
@@ -6,7 +9,6 @@
 
 * Improve output fields for all actions where dataset is included
 * Updated packages
-
 
 ## 3.1.1 / 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.10 / 2025-04-29
+## 4.0.0 / 2025-04-29
 * Authentication with Apify is now possible only via OAuth2
 
 ## 3.2.1 / 2024-11-23

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.2.10",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.2.10",
+      "version": "4.0.0",
       "dependencies": {
         "@apify/consts": "^2.40.0",
         "@apify/utilities": "^2.15.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.2.0",
+  "version": "3.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "3.2.0",
+      "version": "3.2.10",
       "dependencies": {
         "@apify/consts": "^2.40.0",
         "@apify/utilities": "^2.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.2.10",
+  "version": "4.0.0",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "3.2.1",
+  "version": "3.2.10",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -2,6 +2,26 @@ const { ME_USER_NAME_PLACEHOLDER } = require('@apify/consts');
 const { APIFY_API_ENDPOINTS } = require('./consts');
 const { wrapRequestWithRetries } = require('./request_helpers');
 
+const getAccessToken = async (z, bundle) => {
+    const response = await z.request({
+        url: 'https://console-backend.apify.com/oauth/apps/token',
+        method: 'POST',
+        body: {
+            client_id: process.env.CLIENT_ID,
+            client_secret: process.env.CLIENT_SECRET,
+            redirect_uri: '{{bundle.inputData.redirect_uri}}',
+            grant_type: 'authorization_code',
+            code: bundle.inputData.code,
+            code_verifier: '{{bundle.inputData.code_verifier}}', // Added for PKCE
+        },
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    });
+
+    return {
+        token: response.data.access_token,
+    };
+};
+
 // This method can return any truthy value to indicate the credentials are valid.
 const testAuth = async (z) => {
     const response = await wrapRequestWithRetries(z.request, {
@@ -16,21 +36,25 @@ const testAuth = async (z) => {
 };
 
 module.exports = {
-    type: 'custom',
-    fields: [
-        {
-            key: 'token',
-            label: 'API token',
-            required: true,
-            type: 'string',
-            helpText: 'You can find the API token on your '
-                + '**[Apify account](https://console.apify.com/account/integrations)** page.',
+    type: 'oauth2',
+    oauth2Config: {
+        authorizeUrl: {
+            url: 'https://console.apify.com/authorize/oauth',
+            params: {
+                client_id: '{{process.env.CLIENT_ID}}',
+                state: '{{bundle.inputData.state}}',
+                redirect_uri: '{{bundle.inputData.redirect_uri}}',
+                response_type: 'code',
+            },
         },
-    ],
-    // The test method allows Zapier to verify that the credentials a user provides are valid.
+        getAccessToken,
+        autoRefresh: false, // Otherwise it will throw RefreshAuthError which cannot be handled from the intergration
+        enablePkce: true,
+    },
+    fields: [],
     test: testAuth,
-    // This label will be shown after user connect his account.
     connectionLabel: (z, bundle) => {
+        // Values are taken from the "test" response
         return bundle.inputData.username || bundle.inputData.email;
     },
 };

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -18,7 +18,7 @@ const getAccessToken = async (z, bundle) => {
     });
 
     return {
-        token: response.data.access_token,
+        access_token: response.data.access_token,
     };
 };
 

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -8,8 +8,7 @@ const GENERIC_UNHANDLED_ERROR_MESSAGE = 'Oops, Apify API encountered an internal
  */
 const includeApiToken = (request, z, bundle) => {
     if (bundle.authData.token) {
-        request.params = request.params || {};
-        request.params.token = bundle.authData.token;
+        request.headers.Authorization = `Bearer ${bundle.authData.token}`;
     }
     return request;
 };

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -7,8 +7,8 @@ const GENERIC_UNHANDLED_ERROR_MESSAGE = 'Oops, Apify API encountered an internal
  * It runs runs before each request is sent out, allowing you to make tweaks to the request in a centralized spot.
  */
 const includeApiToken = (request, z, bundle) => {
-    if (bundle.authData.token) {
-        request.headers.Authorization = `Bearer ${bundle.authData.token}`;
+    if (bundle.authData.access_token) {
+        request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
     }
     return request;
 };

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -10,7 +10,7 @@ describe('authentication', () => {
     it('passes authentication and returns user', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
         };
 
@@ -18,10 +18,10 @@ describe('authentication', () => {
         expect(tester).to.have.property('username');
     });
 
-    it('throw user error if token is invalide', async () => {
+    it('throw user error if token is invalid', async () => {
         const bundle = {
             authData: {
-                token: 'blabla',
+                access_token: 'blabla',
             },
         };
         try {

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -28,7 +28,7 @@ describe('create actor run', () => {
     it('load correctly Actors with Actors from store with hidden trigger', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {},
             meta: {},
@@ -87,7 +87,7 @@ describe('create actor run', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -109,7 +109,7 @@ describe('create actor run', () => {
         const actorId = 'apify~web-scraper';
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 // Actor with input schema
@@ -156,7 +156,7 @@ describe('create actor run', () => {
     it('loading of dynamic output fields for dataset items work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 // Actor with input schema
@@ -197,7 +197,7 @@ describe('create actor run', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -227,7 +227,7 @@ describe('create actor run', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -259,7 +259,7 @@ describe('create actor run', () => {
     it('runAsync work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -18,7 +18,7 @@ describe('scrape single URL', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: options,
         };
@@ -56,7 +56,7 @@ describe('scrape single URL', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: options,
         };

--- a/test/creates/set_value.js
+++ b/test/creates/set_value.js
@@ -6,7 +6,6 @@ const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
-
 describe('set key-value store value', () => {
     it('work for storeName', async () => {
         const expectedKey = randomString();
@@ -15,7 +14,7 @@ describe('set key-value store value', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: 'zapier-test',
@@ -40,7 +39,7 @@ describe('set key-value store value', () => {
         };
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: store.id,

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -27,7 +27,7 @@ describe('create task run', () => {
         const urlToScrape = 'http://example.com';
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTask1Id,
@@ -55,7 +55,7 @@ describe('create task run', () => {
     it('runSync work without output', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTask2Id,
@@ -74,7 +74,7 @@ describe('create task run', () => {
     it('runAsync work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTask1Id,
@@ -90,7 +90,7 @@ describe('create task run', () => {
     it('run legacy crawler and return simplified items work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTask3Id,

--- a/test/searches/actor_last_run.js
+++ b/test/searches/actor_last_run.js
@@ -20,7 +20,7 @@ describe('search actor last run', () => {
     it('work for actor without run', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -36,7 +36,7 @@ describe('search actor last run', () => {
     it('work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -29,7 +29,7 @@ describe('fetch dataset items', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 datasetIdOrName: testDatasetId,

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -33,7 +33,7 @@ describe('get key-value store value', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: testStoreId,
@@ -57,7 +57,7 @@ describe('get key-value store value', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: testStoreId,
@@ -71,7 +71,7 @@ describe('get key-value store value', () => {
     it('work for empty value', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: testStoreId,

--- a/test/searches/task_last_run.js
+++ b/test/searches/task_last_run.js
@@ -19,7 +19,7 @@ describe('search task last run', () => {
     it('work for task without run', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,
@@ -35,7 +35,7 @@ describe('search task last run', () => {
     it('work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,
@@ -53,11 +53,10 @@ describe('search task last run', () => {
         expect(testResult[0].id).to.be.eql(taskRun.id);
     }).timeout(240000);
 
-
     it('return empty array if there is no run with status', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -23,7 +23,7 @@ describe('actor run finished trigger', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -45,7 +45,7 @@ describe('actor run finished trigger', () => {
     it('unsubscribe webhook work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             subscribeData,
             meta: {},
@@ -62,7 +62,7 @@ describe('actor run finished trigger', () => {
         const runId = randomString();
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -90,7 +90,7 @@ describe('actor run finished trigger', () => {
         }
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 actorId: testActorId,
@@ -111,7 +111,7 @@ describe('actor run finished trigger', () => {
         it('work', async () => {
             const bundle = {
                 authData: {
-                    token: TEST_USER_TOKEN,
+                    access_token: TEST_USER_TOKEN,
                 },
                 inputData: {},
                 meta: {},

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -29,7 +29,7 @@ describe('task run finished trigger', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,
@@ -52,7 +52,7 @@ describe('task run finished trigger', () => {
     it('unsubscribe webhook work', async () => {
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             subscribeData,
             meta: {},
@@ -69,7 +69,7 @@ describe('task run finished trigger', () => {
         const runId = randomString();
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,
@@ -98,7 +98,7 @@ describe('task run finished trigger', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: testTaskId,
@@ -123,7 +123,7 @@ describe('task run finished trigger', () => {
 
         const bundle = {
             authData: {
-                token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 taskId: legacyCrawlerTaskId,
@@ -144,7 +144,7 @@ describe('task run finished trigger', () => {
         it('work', async () => {
             const bundle = {
                 authData: {
-                    token: TEST_USER_TOKEN,
+                    access_token: TEST_USER_TOKEN,
                 },
                 inputData: {},
                 meta: {},


### PR DESCRIPTION
Unfortunately Zapier supports only one authentication. So this is a breaking change as we can not easily support two (direct token + OAauth).

As I understand https://www.notion.so/apify/Apify-as-OAuth-Provider-Docs-192f39950a22807b83a0c8fcbdac90cc there is no workflow for handling refreshing the access token as the tokens provided by us never expires.

Required ENV variables are already set in Zapier.

~~Can be tested with `3.2.10` build.~~