### PR TITLE
fix: Adding new connection with OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1 / 2025-05-13
+* Fix adding new connection issue with OAuth2
+
 ## 4.0.0 / 2025-05-05
 ❗Authentication with Apify is now possible only via OAuth2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -9,10 +9,10 @@ const getAccessToken = async (z, bundle) => {
         body: {
             client_id: process.env.CLIENT_ID,
             client_secret: process.env.CLIENT_SECRET,
-            redirect_uri: '{{bundle.inputData.redirect_uri}}',
+            redirect_uri: bundle.inputData.redirect_uri,
             grant_type: 'authorization_code',
             code: bundle.inputData.code,
-            code_verifier: '{{bundle.inputData.code_verifier}}', // Added for PKCE
+            code_verifier: bundle.inputData.code_verifier, // Added for PKCE
         },
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });


### PR DESCRIPTION
Fixes issue with adding new connection via Apify OAuth.

If this was the problem, then I am not sure how it could work in the past, but I tested these changes and it seems to work fine now.

Can be tested in 4.0.1
