### PR TITLE
feat: Add tracking headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.2 / 2025-05-13
+* Refactor adding integration header to the Apify Platform related requests
+
 ## 4.0.1 / 2025-05-13
 * Fix adding new connection issue with OAuth2
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const zapierCore = require('zapier-platform-core');
 const apifyApp = require('./package.json');
 const authentication = require('./src/authentication');
-const { parseDataApiObject, includeApiToken, validateApiResponse } = require('./src/request_helpers');
+const { parseDataApiObject, setApifyRequestHeaders, validateApiResponse } = require('./src/request_helpers');
 const taskRunFinishedTrigger = require('./src/triggers/task_run_finished');
 const tasksTrigger = require('./src/triggers/tasks');
 const actorRunFinishedTrigger = require('./src/triggers/actor_run_finished');
@@ -28,7 +28,7 @@ const App = {
     authentication,
 
     beforeRequest: [
-        includeApiToken,
+        setApifyRequestHeaders,
     ],
 
     afterResponse: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -4,12 +4,18 @@ const GENERIC_UNHANDLED_ERROR_MESSAGE = 'Oops, Apify API encountered an internal
 
 /**
  * Middleware includes the API token on all outbound requests.
- * It runs runs before each request is sent out, allowing you to make tweaks to the request in a centralized spot.
+ * It runs before each request is sent out, allowing you to make tweaks to the request in a centralized spot.
  */
-const includeApiToken = (request, z, bundle) => {
-    if (bundle.authData.access_token) {
-        request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+const setApifyRequestHeaders = (request, z, bundle) => {
+    const APIFY_HOSTS = ['api.apify.com'];
+
+    if (APIFY_HOSTS.includes(new URL(request.url).host)) {
+        if (bundle.authData.access_token) {
+            request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        }
+        request.headers['x-apify-integration-platform'] = 'zapier';
     }
+
     return request;
 };
 
@@ -84,7 +90,7 @@ const wrapRequestWithRetries = (request, options) => retryWithExpBackoff({
 
 module.exports = {
     parseDataApiObject,
-    includeApiToken,
+    setApifyRequestHeaders,
     validateApiResponse,
     wrapRequestWithRetries,
 };


### PR DESCRIPTION
I set that the `Authorization` header to be used only on api.apify.com related requests - so the token cannot be exposed to other websites via some user input for Request. (I am not currently aware about any that we have, but rather playing it safe now.)

I was thinking about writing a test for this "feature" but It probably require mocking the pure http requests calls or some endpoint on Apify Platform that would confirm the new header.

That is currently non-doable with the current tests, and there is also no such an endpoint on Apify Platform. 
