### PR TITLE
#49: Add support for Apify key-value store records with non-JSON values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 4.0.0 / 2025-04-29
-* Authentication with Apify is now possible only via OAuth2
+## 4.0.0 / 2025-05-05
+❗Authentication with Apify is now possible only via OAuth2
 
 ## 3.2.1 / 2024-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1 / 2025-05-13
+* Fix adding new connection issue with OAuth2
+
 ## 4.0.0 / 2025-05-05
 ❗Authentication with Apify is now possible only via OAuth2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 4.1.0 / 2025-05-12
+* Add support for Apify key-value store records with non-JSON values
+
 ## 4.0.1 / 2025-05-13
 * Fix adding new connection issue with OAuth2
 
 ## 4.0.0 / 2025-05-05
 ❗Authentication with Apify is now possible only via OAuth2
+
+## 4.0.0 / 2025-04-29
+* Authentication with Apify is now possible only via OAuth2
 
 ## 3.2.1 / 2024-11-23
 

--- a/index.js
+++ b/index.js
@@ -51,11 +51,15 @@ const App = {
         [actorsWithStoreTrigger.key]: actorsWithStoreTrigger,
     },
 
+    hydrators: {
+        ...getValueSearch.hydrators,
+    },
+
     // If you want your searches to show up, you better include it here!
     searches: {
         [taskLastRunSearch.key]: taskLastRunSearch,
         [actorLastRunSearch.key]: actorLastRunSearch,
-        [getValueSearch.key]: getValueSearch,
+        [getValueSearch.perform.key]: getValueSearch.perform,
         [fetchItemsSearch.key]: fetchItemsSearch,
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "4.0.0",
+      "version": "3.2.1",
       "dependencies": {
         "@apify/consts": "^2.40.0",
         "@apify/utilities": "^2.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.10",
+  "version": "4.1.0",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.0.0",
+  "version": "4.0.9",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -9,10 +9,10 @@ const getAccessToken = async (z, bundle) => {
         body: {
             client_id: process.env.CLIENT_ID,
             client_secret: process.env.CLIENT_SECRET,
-            redirect_uri: '{{bundle.inputData.redirect_uri}}',
+            redirect_uri: bundle.inputData.redirect_uri,
             grant_type: 'authorization_code',
             code: bundle.inputData.code,
-            code_verifier: '{{bundle.inputData.code_verifier}}', // Added for PKCE
+            code_verifier: bundle.inputData.code_verifier, // Added for PKCE
         },
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -33,7 +33,7 @@ const validateApiResponse = (response, z) => {
     /**
      * NOTE: In case key-value store records request we can skip 404 error
      */
-    if (response.request.method === 'GET' && response.request.url.match(/\/records\//) && response.status === 404) {
+    if (['GET', 'HEAD'].includes(response.request.method) && response.request.url.match(/\/records\//) && response.status === 404) {
         response.skipThrowForStatus = true;
         return response;
     }

--- a/src/searches/get_value.js
+++ b/src/searches/get_value.js
@@ -2,51 +2,91 @@ const { APIFY_API_ENDPOINTS } = require('../consts');
 const { getOrCreateKeyValueStore } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 
+const getRecord = (z, options) => {
+    const { storeId, key, raw } = options;
+    return z.request({
+        url: `${APIFY_API_ENDPOINTS.keyValueStores}/${storeId}/records/${key}`,
+        method: 'GET',
+        raw,
+    });
+};
+
+const stashFunction = (z, bundle) => {
+    const { contentLength, contentType, key } = bundle.inputData;
+    const filePromise = getRecord(z, bundle);
+    return z.stashFile(filePromise, contentLength, key, contentType);
+};
+
 const getValue = async (z, bundle) => {
     const { storeIdOrName, key } = bundle.inputData;
     const store = await getOrCreateKeyValueStore(z, storeIdOrName);
 
-    const recordResponse = await wrapRequestWithRetries(z.request, {
+    const sizeRequest = await wrapRequestWithRetries(z.request, {
         url: `${APIFY_API_ENDPOINTS.keyValueStores}/${store.id}/records/${key}`,
-        method: 'GET',
+        method: 'HEAD',
     });
 
-    if (recordResponse.status === 404) {
+    if (sizeRequest.status === 404) {
         return [];
     }
 
-    if (!recordResponse.data) throw new Error('The value is not JSON object.');
+    const contentType = sizeRequest.getHeader('content-type');
+    const contentLength = sizeRequest.getHeader('content-length');
 
-    return [recordResponse.data];
+    // najit velky soubor 100mb±
+
+    let data;
+    if (contentType === 'application/json' && contentLength < 20 * (1000 ** 2)) {
+        bundle.inputData = { storeId: store.id, key, raw: false };
+        const response = await getRecord(z, { storeId: store.id, key, raw: false });
+        if (typeof response.data === 'object' && !Array.isArray(response.data) && response.data !== null) {
+            data = response.data;
+        } else {
+            data = { value: response.data ?? null };
+        }
+    } else {
+        const pointer = z.dehydrateFile(stashFunction, { storeId: store.id, key, raw: true, contentLength, contentType });
+        data = {
+            contentType,
+            value: pointer,
+        };
+    }
+
+    return [data];
 };
 
 module.exports = {
-    key: 'keyValueStoreGetValue',
-    noun: 'Key-value Store Value',
-    display: {
-        label: 'Get Key-Value Store Record',
-        description: 'Gets a record from a key-value store.',
+    hydrators: {
+        stashFunction,
     },
+    perform: {
+        key: 'keyValueStoreGetValue',
+        noun: 'Key-value Store Value',
+        display: {
+            label: 'Get Key-Value Store Record',
+            description: 'Gets a record from a key-value store.',
+        },
+        operation: {
+            inputFields: [
+                {
+                    label: 'Key-value store',
+                    helpText: 'Key-value store ID or name.',
+                    key: 'storeIdOrName',
+                    required: true,
+                },
+                {
+                    label: 'Record key',
+                    key: 'key',
+                    required: true,
+                    type: 'string',
+                },
+            ],
 
-    operation: {
-        inputFields: [
-            {
-                label: 'Key-value store',
-                helpText: 'Key-value store ID or name.',
-                key: 'storeIdOrName',
-                required: true,
+            perform: getValue,
+            sample: {
+                key: 'This is the sample value from key-value store.',
             },
-            {
-                label: 'Record key',
-                key: 'key',
-                required: true,
-                type: 'string',
-            },
-        ],
-
-        perform: getValue,
-        sample: {
-            key: 'This is the sample value from key-value store.',
         },
     },
+
 };

--- a/src/searches/get_value.js
+++ b/src/searches/get_value.js
@@ -2,18 +2,13 @@ const { APIFY_API_ENDPOINTS } = require('../consts');
 const { getOrCreateKeyValueStore } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 
-const getRecord = (z, options) => {
-    const { storeId, key, raw } = options;
-    return z.request({
+const stashFunction = (z, bundle) => {
+    const { contentLength, contentType, storeId, key } = bundle.inputData;
+    const filePromise = z.request({
         url: `${APIFY_API_ENDPOINTS.keyValueStores}/${storeId}/records/${key}`,
         method: 'GET',
-        raw,
+        raw: true,
     });
-};
-
-const stashFunction = (z, bundle) => {
-    const { contentLength, contentType, key } = bundle.inputData;
-    const filePromise = getRecord(z, bundle);
     return z.stashFile(filePromise, contentLength, key, contentType);
 };
 
@@ -33,18 +28,27 @@ const getValue = async (z, bundle) => {
     const contentType = sizeRequest.getHeader('content-type');
     const contentLength = sizeRequest.getHeader('content-length');
 
-    // najit velky soubor 100mb±
-
     let data;
-    if (contentType === 'application/json' && contentLength < 20 * (1000 ** 2)) {
-        bundle.inputData = { storeId: store.id, key, raw: false };
-        const response = await getRecord(z, { storeId: store.id, key, raw: false });
+
+    const PARSEABLE_MIMES = ['application/json', 'text/plain'];
+
+    // Maximum HTTP response payload = 20MB
+    if (PARSEABLE_MIMES.includes(contentType) && contentLength < 20 * (1000 ** 2)) {
+        const response = await z.request({
+            url: `${APIFY_API_ENDPOINTS.keyValueStores}/${store.id}/records/${key}`,
+            method: 'GET',
+        });
         if (typeof response.data === 'object' && !Array.isArray(response.data) && response.data !== null) {
             data = response.data;
         } else {
             data = { value: response.data ?? null };
         }
     } else {
+        // There is a hard limit of 150MB on the size of dehydrated files.
+        // Depending on the complexity of the app, issues can also occur for files over ~100MB
+        if (contentLength > 120 * (1000 ** 2)) {
+            throw new Error('File size exceeds Zapier operating constraints.');
+        }
         const pointer = z.dehydrateFile(stashFunction, { storeId: store.id, key, raw: true, contentLength, contentType });
         data = {
             contentType,

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -19,39 +19,14 @@ describe('get key-value store value', () => {
         testStoreId = store.id;
     });
 
-    it('work for JSON with object structure', async () => {
+    it('work', async () => {
         const storeKey = randomString();
-        const storeValue = { key: 'value' };
+        const storeValue = 'j{}';
         // Create record
         await apifyClient.keyValueStore(testStoreId).setRecord({
             key: storeKey,
             contentType: 'application/json',
-            value: storeValue,
-        });
-
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {
-                storeIdOrName: testStoreId,
-                key: storeKey,
-            },
-        };
-
-        const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
-
-        expect(storeValue).to.be.eql(testResult[0]);
-    }).timeout(10000);
-
-    it('work for JSON without object structure', async () => {
-        const storeKey = randomString();
-        const storeValue = 'Just some text.';
-        // Create record
-        await apifyClient.keyValueStore(testStoreId).setRecord({
-            key: storeKey,
-            contentType: 'application/json',
-            value: storeValue,
+            value: true,
         });
 
         const bundle = {
@@ -85,13 +60,13 @@ describe('get key-value store value', () => {
         expect(testResult).to.be.eql([]);
     }).timeout(10000);
 
-    it('work for pdf', async () => {
+    it('work for existing pdf', async () => {
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,
             },
             inputData: {
-                storeIdOrName: 'oDtbjvjH3vIjUYWsy', // TODO: move to test user account
+                storeIdOrName: 'oDtbjvjH3vIjUYWsy',
                 key: 'pdf',
             },
         };
@@ -100,33 +75,14 @@ describe('get key-value store value', () => {
 
         expect(testResult).to.be.eql([{
             contentType: 'application/pdf',
-            value: 'hydrate|||{'
-                + '"type":"file",'
-                + '"method":"hydrators.stashFunction",'
-                + '"bundle":{'
-                + '"storeId":"oDtbjvjH3vIjUYWsy",'
+            value: 'hydrate|||'
+                + '{"type":"file",'
+                + '"method":"searches.keyValueStoreGetValue.hydrators.getRecord",'
+                + '"bundle":{"storeId":"oDtbjvjH3vIjUYWsy",'
                 + '"key":"pdf",'
-                + '"raw":true,'
-                + '"contentLength":"196420",'
-                + '"contentType":"application/pdf"'
-                + '}'
-                + '}|||hydrate',
+                + '"raw":true}}'
+                + '|||hydrate',
         }]);
-    }).timeout(10000);
-
-    it('throw for file bigger than 120MB', async () => {
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {
-                storeIdOrName: 'oDtbjvjH3vIjUYWsy', // TODO: move to test user account
-                key: '200MBzip',
-            },
-        };
-
-        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle)).to.be
-            .rejectedWith(/File size exceeds Zapier operating constraints/);
     }).timeout(10000);
 
     after(async () => {

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -21,14 +21,12 @@ describe('get key-value store value', () => {
 
     it('work', async () => {
         const storeKey = randomString();
-        const storeValue = {
-            myKey: randomString(),
-        };
+        const storeValue = 'j{}';
         // Create record
         await apifyClient.keyValueStore(testStoreId).setRecord({
             key: storeKey,
             contentType: 'application/json',
-            value: JSON.stringify(storeValue),
+            value: true,
         });
 
         const bundle = {
@@ -43,29 +41,7 @@ describe('get key-value store value', () => {
 
         const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
 
-        expect(storeValue).to.be.eql(testResult[0]);
-    }).timeout(10000);
-
-    it('throw error for non json value', async () => {
-        const storeKey = randomString();
-        // Create record
-        await apifyClient.keyValueStore(testStoreId).setRecord({
-            key: storeKey,
-            contentType: 'plain/text',
-            value: 'just text',
-        });
-
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {
-                storeIdOrName: testStoreId,
-                key: storeKey,
-            },
-        };
-
-        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle)).to.be.rejectedWith(/is not JSON object/);
+        expect(storeValue).to.be.eql(testResult[0].value);
     }).timeout(10000);
 
     it('work for empty value', async () => {
@@ -82,6 +58,31 @@ describe('get key-value store value', () => {
         const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
 
         expect(testResult).to.be.eql([]);
+    }).timeout(10000);
+
+    it('work for existing pdf', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                storeIdOrName: 'oDtbjvjH3vIjUYWsy',
+                key: 'pdf',
+            },
+        };
+
+        const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
+
+        expect(testResult).to.be.eql([{
+            contentType: 'application/pdf',
+            value: 'hydrate|||'
+                + '{"type":"file",'
+                + '"method":"searches.keyValueStoreGetValue.hydrators.getRecord",'
+                + '"bundle":{"storeId":"oDtbjvjH3vIjUYWsy",'
+                + '"key":"pdf",'
+                + '"raw":true}}'
+                + '|||hydrate',
+        }]);
     }).timeout(10000);
 
     after(async () => {


### PR DESCRIPTION
Integration version 4.1.0 is pushed to Zapier platform. It should be able to handle application/json records as it was previously, plus handle valid, but non-object looking JSONs and plain/text returned in {value:...} format. Big files of mentioned content types and all of other types are being dehydrated with stashing step.
File size caps we introduced for both direct requests and stashed files.