### PR TITLE
feat: Improve test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,21 @@ jobs:
             - run: zapier validate --without-style
             - run: npm run lint
             - run: npm run test
-              env:
-                  TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
+
+    run-e2e-test:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Use Node.js
+                uses: actions/setup-node@v3
+                with:
+                    node-version-file: '.nvmrc'
+            -   run: npm install -g zapier-platform-cli
+            -   run: npm install
+            -   run: zapier validate --without-style
+            -   run: npm run lint
+            -   run: npm run test
+                env:
+                    TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ If you are interested in adding a new feature or fixing a bug in the integration
 
 ### Tests
 
-You will need your Apify API token before you run tests.
+The test suite is able to run against the Apify platform or it can mock any requests to the Apify API.
+
+Mocked tests are invoked by running:
+```
+npm run test
+```
+
+But if you want to run the tests against the Apify platform you will need your Apify API token before you run tests.
 You can find the token [on the Integrations page of your Apify account](https://console.apify.com/account/integrations).
 Run this command to test the app:
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,4 @@
-{
+jj s{
   "name": "apify-zapier-integration",
   "version": "4.1.0",
   "lockfileVersion": 3,

--- a/test/apify_helpers.js
+++ b/test/apify_helpers.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const { expect } = require('chai');
 const FieldSchema = require('zapier-platform-schema/lib/schemas/FieldSchema');
 const makeValidator = require('zapier-platform-schema/lib/utils/makeValidator');

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -1,5 +1,7 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
+const nock = require('nock');
 const { TEST_USER_TOKEN } = require('./helpers');
 
 const App = require('../index');
@@ -7,6 +9,12 @@ const App = require('../index');
 const appTester = zapier.createAppTester(App);
 
 describe('authentication', () => {
+    afterEach(() => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
     it('passes authentication and returns user', async () => {
         const bundle = {
             authData: {
@@ -14,8 +22,18 @@ describe('authentication', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/users/me')
+                .reply(200, {
+                    username: 'testUser',
+                });
+        }
+
         const tester = await appTester(App.authentication.test, bundle);
         expect(tester).to.have.property('username');
+        scope?.done();
     });
 
     it('throw user error if token is invalid', async () => {

--- a/test/consts.js
+++ b/test/consts.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const { expect } = require('chai');
 const { ACTOR_LIMITS: { MIN_RUN_MEMORY_MBYTES } } = require('@apify/consts');
 const { APIFY_API_ENDPOINTS, ALLOWED_MEMORY_MBYTES_LIST } = require('../src/consts');
@@ -5,8 +6,8 @@ const { APIFY_API_ENDPOINTS, ALLOWED_MEMORY_MBYTES_LIST } = require('../src/cons
 describe('consts', () => {
     it('APIFY_API_ENDPOINTS work', () => {
         // If test failed apify-client-js was changed
-        expect(APIFY_API_ENDPOINTS.tasks).to.be.eql(`https://api.apify.com/v2/actor-tasks`);
-        expect(APIFY_API_ENDPOINTS.webhooks).to.be.eql(`https://api.apify.com/v2/webhooks`);
+        expect(APIFY_API_ENDPOINTS.tasks).to.be.eql('https://api.apify.com/v2/actor-tasks');
+        expect(APIFY_API_ENDPOINTS.webhooks).to.be.eql('https://api.apify.com/v2/webhooks');
     });
 
     it('ALLOWED_MEMORY_MBYTES_LIST work', () => {

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -1,23 +1,24 @@
+/* eslint-env mocha */
 const axios = require('axios');
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const _ = require('lodash');
 const nock = require('nock');
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 
-const { createAndBuildActor, TEST_USER_TOKEN, apifyClient, getMockActorDetails, getMockActorBuild, randomString} = require('../helpers');
-const { ACTOR_RUN_SAMPLE} = require('../../src/consts');
+const { createAndBuildActor, TEST_USER_TOKEN, apifyClient, getMockActorDetails, randomString } = require('../helpers');
+const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
 
 const searchApiBaseUrl = 'https://api.apify.com/v2/store';
 
 const App = require('../../index');
-const {ACTOR_JOB_STATUSES} = require("@apify/consts");
 
 const appTester = zapier.createAppTester(App);
 
 describe('create actor run', () => {
     let testActorId = randomString();
 
-    before(async () => {
+    before(async function () {
         if (TEST_USER_TOKEN) {
             this.timeout(120000); // We need time to build actor
             // Create actor for testing
@@ -52,16 +53,16 @@ describe('create actor run', () => {
             const allUserActors = [];
             let actorListPage;
             do {
-                actorListPage = await apifyClient.actors().list({limit: 500, offset: allUserActors.length});
+                actorListPage = await apifyClient.actors().list({ limit: 500, offset: allUserActors.length });
                 allUserActors.push(...actorListPage.items);
             } while (actorListPage.items.length > 0);
 
             const allPublicActor = [];
             let storeActorList;
             do {
-                ({data: {data: storeActorList}} = await axios({
+                ({ data: { data: storeActorList } } = await axios({
                     url: searchApiBaseUrl,
-                    params: {offset: allPublicActor.length, limit: 100},
+                    params: { offset: allPublicActor.length, limit: 100 },
                 }));
                 allPublicActor.push(...storeActorList.items);
             } while (storeActorList.items.length);

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -2,74 +2,90 @@ const axios = require('axios');
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const _ = require('lodash');
-const { createAndBuildActor, TEST_USER_TOKEN, apifyClient } = require('../helpers');
-const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
+const nock = require('nock');
+
+const { createAndBuildActor, TEST_USER_TOKEN, apifyClient, getMockActorDetails, getMockActorBuild, randomString} = require('../helpers');
+const { ACTOR_RUN_SAMPLE} = require('../../src/consts');
 
 const searchApiBaseUrl = 'https://api.apify.com/v2/store';
 
 const App = require('../../index');
+const {ACTOR_JOB_STATUSES} = require("@apify/consts");
 
 const appTester = zapier.createAppTester(App);
 
 describe('create actor run', () => {
-    let testActorId;
+    let testActorId = randomString();
 
-    before(async function () {
-        this.timeout(120000); // We need time to build actor
-        // Create actor for testing
-        const actor = await createAndBuildActor();
-        testActorId = actor.id;
+    before(async () => {
+        if (TEST_USER_TOKEN) {
+            this.timeout(120000); // We need time to build actor
+            // Create actor for testing
+            const actor = await createAndBuildActor();
+            testActorId = actor.id;
+        }
     });
 
     after(async () => {
-        await apifyClient.actor(testActorId).delete();
+        if (TEST_USER_TOKEN) {
+            await apifyClient.actor(testActorId).delete();
+        }
     });
 
-    it('load correctly Actors with Actors from store with hidden trigger', async () => {
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {},
-            meta: {},
-        };
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
 
-        const allUserActors = [];
-        let actorListPage;
-        do {
-            actorListPage = await apifyClient.actors().list({ limit: 500, offset: allUserActors.length });
-            allUserActors.push(...actorListPage.items);
-        } while (actorListPage.items.length > 0);
-
-        const allPublicActor = [];
-        let storeActorList;
-        do {
-            ({ data: { data: storeActorList } } = await axios({
-                url: searchApiBaseUrl,
-                params: { offset: allPublicActor.length, limit: 100 },
-            }));
-            allPublicActor.push(...storeActorList.items);
-        } while (storeActorList.items.length);
-
-        const actors = [];
-        let page = 0;
-        let actorList;
-        do {
-            actorList = await appTester(App.triggers.actorsWithStore.operation.perform, {
-                ...bundle,
-                meta: {
-                    page: page === 0 ? undefined : page,
+    // This test whether retrieving actors from store works
+    if (TEST_USER_TOKEN) {
+        it('load correctly Actors with Actors from store with hidden trigger', async () => {
+            const bundle = {
+                authData: {
+                    access_token: TEST_USER_TOKEN,
                 },
-            });
-            actors.push(...actorList);
-            page++;
-        } while (actorList.length);
+                inputData: {},
+                meta: {},
+            };
 
-        expect(allUserActors.concat(allPublicActor).map((a) => a.id)).to.include.members(actors.map((a) => a.id));
-        actors.forEach((actor) => {
-            expect(actor).to.have.all.keys('id', 'name');
-        });
-    }).timeout(120000);
+            const allUserActors = [];
+            let actorListPage;
+            do {
+                actorListPage = await apifyClient.actors().list({limit: 500, offset: allUserActors.length});
+                allUserActors.push(...actorListPage.items);
+            } while (actorListPage.items.length > 0);
+
+            const allPublicActor = [];
+            let storeActorList;
+            do {
+                ({data: {data: storeActorList}} = await axios({
+                    url: searchApiBaseUrl,
+                    params: {offset: allPublicActor.length, limit: 100},
+                }));
+                allPublicActor.push(...storeActorList.items);
+            } while (storeActorList.items.length);
+
+            const actors = [];
+            let page = 0;
+            let actorList;
+            do {
+                actorList = await appTester(App.triggers.actorsWithStore.operation.perform, {
+                    ...bundle,
+                    meta: {
+                        page: page === 0 ? undefined : page,
+                    },
+                });
+                actors.push(...actorList);
+                page++;
+            } while (actorList.length);
+
+            expect(allUserActors.concat(allPublicActor).map((a) => a.id)).to.include.members(actors.map((a) => a.id));
+            actors.forEach((actor) => {
+                expect(actor).to.have.all.keys('id', 'name');
+            });
+        }).timeout(120000);
+    }
 
     it('loading of dynamic fields from exampleRunInput work', async () => {
         const actorFields = {
@@ -83,7 +99,10 @@ describe('create actor run', () => {
                 body: JSON.stringify({ myField: 'myValue' }),
             },
         };
-        await apifyClient.actor(testActorId).update(actorFields);
+
+        if (TEST_USER_TOKEN) {
+            await apifyClient.actor(testActorId).update(actorFields);
+        }
 
         const bundle = {
             authData: {
@@ -94,64 +113,77 @@ describe('create actor run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/acts/${testActorId}`)
+                .reply(200, {
+                    data: getMockActorDetails(actorFields),
+                });
+        }
+
         const fields = await appTester(App.triggers.getActorAdditionalFieldsTest.operation.perform, bundle);
         const fieldsByKey = _.keyBy(fields, 'key');
 
         expect(actorFields.defaultRunOptions.build).to.be.eql(fieldsByKey.build.default);
         expect(actorFields.defaultRunOptions.timeoutSecs).to.be.eql(fieldsByKey.timeoutSecs.default);
-        expect(actorFields.defaultRunOptions.memoryMbytes).to.be.eql(parseInt(fieldsByKey.memoryMbytes.default));
+        expect(actorFields.defaultRunOptions.memoryMbytes).to.be.eql(parseInt(fieldsByKey.memoryMbytes.default, 10));
         expect(actorFields.exampleRunInput.contentType).to.be.eql(fieldsByKey.inputContentType.default);
         expect(JSON.parse(actorFields.exampleRunInput.body)).to.be.eql(JSON.parse(fieldsByKey.inputBody.default));
+
+        scope?.done();
     });
 
-    it('loading of dynamic fields from inputSchema work', async () => {
-        // Actor with input schema
-        const actorId = 'apify~web-scraper';
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {
-                // Actor with input schema
-                actorId,
-            },
-        };
-        const actor = await apifyClient.actor(actorId).get();
-        const { buildId } = actor.taggedBuilds[actor.defaultRunOptions.build];
-        const { inputSchema } = await apifyClient.build(buildId).get();
-        const { properties } = JSON.parse(inputSchema);
+    if (TEST_USER_TOKEN) {
+        it('loading of dynamic fields from inputSchema work', async () => {
+            // Actor with input schema
+            const actorId = 'apify~web-scraper';
+            const bundle = {
+                authData: {
+                    access_token: TEST_USER_TOKEN,
+                },
+                inputData: {
+                    // Actor with input schema
+                    actorId,
+                },
+            };
+            const actor = await apifyClient.actor(actorId).get();
+            const { buildId } = actor.taggedBuilds[actor.defaultRunOptions.build];
+            const { inputSchema } = await apifyClient.build(buildId).get();
+            const { properties } = JSON.parse(inputSchema);
 
-        const fields = await appTester(App.triggers.getActorAdditionalFieldsTest.operation.perform, bundle);
-        const fieldKeys = fields.map(({ key }) => key);
-        Object.keys(properties).forEach((keyToFind) => {
-            expect(fieldKeys.includes(`input-${keyToFind}`)).to.be.equal(true);
-        });
-        // Test fields edge cases
-        const startUrlsField = fields.find(({ key }) => key === 'input-startUrls');
-        const startUrlsFieldSchema = properties.startUrls;
-        expect(startUrlsField.label).to.be.equal(startUrlsFieldSchema.title);
-        expect(startUrlsField.helpText).to.be.equal(startUrlsFieldSchema.description);
-        expect(startUrlsField.default).to.be.deep.equal(startUrlsFieldSchema.prefill.map(({ url }) => url)[0]);
+            const fields = await appTester(App.triggers.getActorAdditionalFieldsTest.operation.perform, bundle);
+            const fieldKeys = fields.map(({ key }) => key);
+            Object.keys(properties).forEach((keyToFind) => {
+                expect(fieldKeys.includes(`input-${keyToFind}`)).to.be.equal(true);
+            });
+            // Test fields edge cases
+            const startUrlsField = fields.find(({ key }) => key === 'input-startUrls');
+            const startUrlsFieldSchema = properties.startUrls;
+            expect(startUrlsField.label).to.be.equal(startUrlsFieldSchema.title);
+            expect(startUrlsField.helpText).to.be.equal(startUrlsFieldSchema.description);
+            expect(startUrlsField.default).to.be.deep.equal(startUrlsFieldSchema.prefill.map(({ url }) => url)[0]);
 
-        const pseudoUrlsField = fields.find(({ key }) => key === 'input-pseudoUrls');
-        const pseudoUrlsFieldSchema = properties.pseudoUrls;
-        expect(pseudoUrlsField.label).to.be.equal(pseudoUrlsFieldSchema.title);
-        expect(pseudoUrlsField.helpText).to.be.equal(pseudoUrlsFieldSchema.description);
-        expect(pseudoUrlsField.default).to.be.deep.equal(pseudoUrlsFieldSchema.prefill.map(({ purl }) => purl)[0]);
+            const pseudoUrlsField = fields.find(({ key }) => key === 'input-pseudoUrls');
+            const pseudoUrlsFieldSchema = properties.pseudoUrls;
+            expect(pseudoUrlsField.label).to.be.equal(pseudoUrlsFieldSchema.title);
+            expect(pseudoUrlsField.helpText).to.be.equal(pseudoUrlsFieldSchema.description);
+            expect(pseudoUrlsField.default).to.be.deep.equal(pseudoUrlsFieldSchema.prefill.map(({ purl }) => purl)[0]);
 
-        const proxyConfigurationField = fields.find(({ key }) => key === 'input-proxyConfiguration');
-        const proxyConfigurationFieldSchema = properties.proxyConfiguration;
-        expect(proxyConfigurationField.label).to.be.equal(proxyConfigurationFieldSchema.title);
-        expect(proxyConfigurationField.helpText).to.be.equal(proxyConfigurationFieldSchema.description);
-        expect(proxyConfigurationField.default).to.be.equal(JSON.stringify(proxyConfigurationFieldSchema.prefill, null, 2));
+            const proxyConfigurationField = fields.find(({ key }) => key === 'input-proxyConfiguration');
+            const proxyConfigurationFieldSchema = properties.proxyConfiguration;
+            expect(proxyConfigurationField.label).to.be.equal(proxyConfigurationFieldSchema.title);
+            expect(proxyConfigurationField.helpText).to.be.equal(proxyConfigurationFieldSchema.description);
+            expect(proxyConfigurationField.default).to.be.equal(JSON.stringify(proxyConfigurationFieldSchema.prefill, null, 2));
 
-        const waitUntilField = fields.find(({ key }) => key === 'input-waitUntil');
-        const waitUntilFieldSchema = properties.waitUntil;
-        expect(waitUntilField.label).to.be.equal(waitUntilFieldSchema.title);
-        expect(waitUntilField.helpText).to.be.equal(waitUntilFieldSchema.description);
-        expect(waitUntilField.type).to.be.equal('text');
-        expect(waitUntilField.default).to.be.equal(JSON.stringify(waitUntilFieldSchema.prefill, null, 2));
-    }).timeout(120000);
+            const waitUntilField = fields.find(({ key }) => key === 'input-waitUntil');
+            const waitUntilFieldSchema = properties.waitUntil;
+            expect(waitUntilField.label).to.be.equal(waitUntilFieldSchema.title);
+            expect(waitUntilField.helpText).to.be.equal(waitUntilFieldSchema.description);
+            expect(waitUntilField.type).to.be.equal('text');
+            expect(waitUntilField.default).to.be.equal(JSON.stringify(waitUntilFieldSchema.prefill, null, 2));
+        }).timeout(120000);
+    }
 
     it('loading of dynamic output fields for dataset items work', async () => {
         const bundle = {
@@ -170,10 +202,23 @@ describe('create actor run', () => {
             { a: 4, b: 5, f: new Date() },
             { a: 4, b: 5, g: ['a', 'b'], h: [{ a: 1, b: 2 }] },
         ];
-        // Run an Actor, the output items will be generated based on latest success run
-        await apifyClient.actor(testActorId).call({
-            datasetItems: items,
-        }, { build: 'latest' });
+
+        let scope;
+        if (TEST_USER_TOKEN) {
+            // Run an Actor, the output items will be generated based on latest success run
+            await apifyClient.actor(testActorId).call({
+                datasetItems: items,
+            }, { build: 'latest' });
+        } else {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/acts/${testActorId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.SUCCEEDED })
+                .reply(200, { data: ACTOR_RUN_SAMPLE });
+            scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 10, clean: true })
+                .reply(200, items);
+        }
+
         const fields = await appTester(App.triggers.getActorDatasetOutputFieldsTest.operation.perform, bundle);
         expect(fields).to.be.eql([
             { key: 'datasetItems[]a', type: 'number' },
@@ -187,6 +232,8 @@ describe('create actor run', () => {
             { key: 'datasetItems[]h[]a', type: 'number' },
             { key: 'datasetItems[]h[]b', type: 'number' },
         ]);
+
+        scope?.done();
     }).timeout(120000);
 
     it('runSync work', async () => {
@@ -207,6 +254,26 @@ describe('create actor run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/acts/${testActorId}/runs`)
+                .query({
+                    timeout: runOptions.timeoutSecs,
+                    memory: runOptions.memoryMbytes,
+                    build: runOptions.build,
+                    waitForFinish: runOptions.timeoutSecs,
+                })
+                .reply(200, { data: ACTOR_RUN_SAMPLE });
+            scope.get(`/v2/actor-runs/${ACTOR_RUN_SAMPLE.id}`)
+                .reply(200, { data: { ...ACTOR_RUN_SAMPLE, options: runOptions } });
+            scope.get(`/v2/key-value-stores/${ACTOR_RUN_SAMPLE.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, { foo: 'bar' });
+            scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+        }
+
         const testResult = await appTester(App.creates.createActorRun.operation.perform, bundle);
         const actorRun = await apifyClient.run(testResult.id).get();
 
@@ -217,6 +284,8 @@ describe('create actor run', () => {
         Object.keys(runOptions).forEach((key) => {
             expect(actorRun.options[key]).to.be.eql(runOptions[key]);
         });
+
+        scope?.done();
     }).timeout(120000);
 
     it('runSync handles output as file', async () => {
@@ -240,6 +309,30 @@ describe('create actor run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/acts/${testActorId}/runs`)
+                .query({
+                    timeout: runOptions.timeoutSecs,
+                    memory: runOptions.memoryMbytes,
+                    build: runOptions.build,
+                    waitForFinish: runOptions.timeoutSecs,
+                })
+                .reply(200, { data: ACTOR_RUN_SAMPLE });
+            scope.get(`/v2/actor-runs/${ACTOR_RUN_SAMPLE.id}`)
+                .reply(200, { data: { ...ACTOR_RUN_SAMPLE, options: runOptions } });
+            scope.get(`/v2/key-value-stores/${ACTOR_RUN_SAMPLE.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, {
+                    file: `https://api.apify.com/v2/key-value-stores/${ACTOR_RUN_SAMPLE.defaultKeyValueStoreId}/records/OUTPUT`,
+                    filename: 'OUTPUT',
+                    contentType: 'text/plain; charset=utf-8',
+                });
+            scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+        }
+
         const testResult = await appTester(App.creates.createActorRun.operation.perform, bundle);
         const actorRun = await apifyClient.run(testResult.id).get();
 
@@ -254,6 +347,8 @@ describe('create actor run', () => {
         Object.keys(runOptions).forEach((key) => {
             expect(actorRun.options[key]).to.be.eql(runOptions[key]);
         });
+
+        scope?.done();
     }).timeout(120000);
 
     it('runAsync work', async () => {
@@ -271,8 +366,30 @@ describe('create actor run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockActorRun = { ...ACTOR_RUN_SAMPLE, finishedAt: null };
+            delete mockActorRun.exitCode;
+
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/acts/${testActorId}/runs`)
+                .query({
+                    timeout: 120,
+                    memory: 1024,
+                    build: 'latest',
+                })
+                .reply(200, { data: mockActorRun });
+            scope.get(`/v2/key-value-stores/${mockActorRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, {});
+            scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, []);
+        }
+
         const testResult = await appTester(App.creates.createActorRun.operation.perform, bundle);
         expect(testResult).to.have.all.keys(_.without(Object.keys(ACTOR_RUN_SAMPLE), 'exitCode'));
         expect(testResult.finishedAt).to.be.eql(null);
+
+        scope?.done();
     }).timeout(50000);
 });

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -2,16 +2,23 @@ const { expect } = require('chai');
 const zapier = require('zapier-platform-core');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const { TEST_USER_TOKEN, apifyClient } = require('../helpers');
+const nock = require('nock');
+const { TEST_USER_TOKEN, apifyClient, getMockRun} = require('../helpers');
 const App = require('../../index');
-const { SCRAPE_SINGLE_URL_RUN_SAMPLE } = require('../../src/consts');
+const { SCRAPE_SINGLE_URL_RUN_SAMPLE, ACTOR_RUN_SAMPLE} = require('../../src/consts');
 
 const appTester = zapier.createAppTester(App);
 
 chai.use(chaiAsPromised);
 
 describe('scrape single URL', () => {
-    it('runs scrape single URL with correct output fields', async () => {
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
+    it('runs scrape single URL with correct output fields (mocked)', async () => {
         const options = {
             url: 'https://www.example.com',
             crawlerType: 'cheerio',
@@ -23,31 +30,108 @@ describe('scrape single URL', () => {
             inputData: options,
         };
 
+        const mockRun = getMockRun({
+            actId: 'aYG0l9s7dbB7j3gbS',
+            isStatusMessageTerminal: true,
+            statusMessage: 'OK',
+        });
+        delete mockRun.OUTPUT;
+        delete mockRun.datasetItems;
+        delete mockRun.datasetItemsFileUrls;
+        delete mockRun.consoleUrl;
+
+        const mockDatasetItem = {
+            url: 'https://www.example.com',
+            metadata: {
+                canonicalUrl: 'https://example.com/',
+                title: 'Example Domain',
+                description: null,
+                author: null,
+                keywords: null,
+                languageCode: null,
+            },
+            html: '<html><head><title>Example Domain</title></head><body></body></html>',
+            markdown: '# Example Domain\n\nThis domain is for use in illustrative examples in documents.',
+            text: 'Example Domain\n\nThis domain is for use in illustrative examples in documents.',
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.post(`/v2/acts/${mockRun.actId}/runs`, {
+            startUrls: [{ url: options.url }],
+            crawlerType: options.crawlerType,
+            maxCrawlDepth: 0,
+            maxCrawlPages: 1,
+            maxResults: 1,
+            proxyConfiguration: {
+                useApifyProxy: true,
+            },
+            removeCookieWarnings: true,
+            saveHtml: true,
+            saveMarkdown: true,
+        })
+            .query({
+                timeout: 30,
+                memory: 1024,
+                waitForFinish: 28,
+            })
+            .reply(200, { data: mockRun });
+        scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+            .query({ limit: 1, clean: true })
+            .reply(200, [mockDatasetItem]);
+
         const testResult = await appTester(App.creates.scrapeSingleUrl.operation.perform, bundle);
-        const scrapeSingleUrlRun = await apifyClient.run(testResult.id).get();
-        const datasetClient = await apifyClient.dataset(scrapeSingleUrlRun.defaultDatasetId);
-        const datasetItems = await datasetClient.listItems({ limit: 1 });
-        const kvsClient = await apifyClient.keyValueStore(scrapeSingleUrlRun.defaultKeyValueStoreId);
-        const input = await kvsClient.getRecord('INPUT');
 
         expect(testResult).to.have.all.keys(Object.keys(SCRAPE_SINGLE_URL_RUN_SAMPLE));
-        expect(scrapeSingleUrlRun.status).to.be.eql('SUCCEEDED');
-        // Run scraper just one single URL
-        expect(datasetItems.items.length).to.be.eql(1);
+        expect(testResult.detailsPageUrl).to.eql(`https://console.apify.com/actors/${mockRun.actId}/runs/${mockRun.id}`);
+        expect(testResult.pageUrl).to.eql('https://www.example.com');
+        expect(testResult.pageMetadata).to.eql(mockDatasetItem.metadata);
+        expect(testResult.pageContent).to.have.all.keys(['html', 'markdown', 'text']);
+        expect(testResult.pageContent.html).to.eql(mockDatasetItem.html);
+        expect(testResult.pageContent.markdown).to.equal(mockDatasetItem.markdown);
+        expect(testResult.pageContent.text).to.equal(mockDatasetItem.text);
 
-        // Correctly set type of crawler
-        expect(input.value.crawlerType).to.be.eql(options.crawlerType);
+        scope.done();
+    });
 
-        // Check that output fields are correct
-        const result = datasetItems.items[0];
-        expect(testResult.pageUrl).to.be.eql(result.url);
-        expect(testResult.pageContent).to.be.eql({
-            html: result.html,
-            markdown: result.markdown,
-            text: result.text,
-        });
-        expect(testResult.pageMetadata).to.be.eql(result.metadata);
-    }).timeout(60000);
+    if (TEST_USER_TOKEN) {
+        it('runs scrape single URL with correct output fields (E2E)', async () => {
+            const options = {
+                url: 'https://www.example.com',
+                crawlerType: 'cheerio',
+            };
+            const bundle = {
+                authData: {
+                    access_token: TEST_USER_TOKEN,
+                },
+                inputData: options,
+            };
+
+            const testResult = await appTester(App.creates.scrapeSingleUrl.operation.perform, bundle);
+            const scrapeSingleUrlRun = await apifyClient.run(testResult.id).get();
+            const datasetClient = await apifyClient.dataset(scrapeSingleUrlRun.defaultDatasetId);
+            const datasetItems = await datasetClient.listItems({limit: 1});
+            const kvsClient = await apifyClient.keyValueStore(scrapeSingleUrlRun.defaultKeyValueStoreId);
+            const input = await kvsClient.getRecord('INPUT');
+
+            expect(testResult).to.have.all.keys(Object.keys(SCRAPE_SINGLE_URL_RUN_SAMPLE));
+            expect(scrapeSingleUrlRun.status).to.be.eql('SUCCEEDED');
+            // Run scraper just one single URL
+            expect(datasetItems.items.length).to.be.eql(1);
+
+            // Correctly set type of crawler
+            expect(input.value.crawlerType).to.be.eql(options.crawlerType);
+
+            // Check that output fields are correct
+            const result = datasetItems.items[0];
+            expect(testResult.pageUrl).to.be.eql(result.url);
+            expect(testResult.pageContent).to.be.eql({
+                html: result.html,
+                markdown: result.markdown,
+                text: result.text,
+            });
+            expect(testResult.pageMetadata).to.be.eql(result.metadata);
+        }).timeout(60000);
+    }
 
     it('throws if there are no data', async () => {
         const options = {
@@ -60,6 +144,35 @@ describe('scrape single URL', () => {
             },
             inputData: options,
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.post('/v2/acts/aYG0l9s7dbB7j3gbS/runs', {
+                startUrls: [{ url: options.url }],
+                crawlerType: options.crawlerType,
+                maxCrawlDepth: 0,
+                maxCrawlPages: 1,
+                maxResults: 1,
+                proxyConfiguration: {
+                    useApifyProxy: true,
+                },
+                removeCookieWarnings: true,
+                saveHtml: true,
+                saveMarkdown: true,
+            })
+                .query({
+                    timeout: 30,
+                    memory: 1024,
+                    waitForFinish: 28,
+                })
+                .reply(200, { data: SCRAPE_SINGLE_URL_RUN_SAMPLE });
+            scope.get(`/v2/datasets/${SCRAPE_SINGLE_URL_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, []);
+        }
+
         await expect(appTester(App.creates.scrapeSingleUrl.operation.perform, bundle)).to.be.rejectedWith(/page content is missing/);
+        scope?.done();
     }).timeout(65000);
 });

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const { expect } = require('chai');
 const zapier = require('zapier-platform-core');
 const chai = require('chai');
@@ -13,9 +14,7 @@ chai.use(chaiAsPromised);
 
 describe('scrape single URL', () => {
     afterEach(async () => {
-        if (!TEST_USER_TOKEN) {
-            nock.cleanAll();
-        }
+        nock.cleanAll();
     });
 
     it('runs scrape single URL with correct output fields (mocked)', async () => {

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -6,7 +6,7 @@ const chaiAsPromised = require('chai-as-promised');
 const nock = require('nock');
 const { TEST_USER_TOKEN, apifyClient, getMockRun} = require('../helpers');
 const App = require('../../index');
-const { SCRAPE_SINGLE_URL_RUN_SAMPLE, ACTOR_RUN_SAMPLE} = require('../../src/consts');
+const { SCRAPE_SINGLE_URL_RUN_SAMPLE } = require('../../src/consts');
 
 const appTester = zapier.createAppTester(App);
 

--- a/test/creates/set_value.js
+++ b/test/creates/set_value.js
@@ -2,31 +2,11 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
-const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
+const { TEST_USER_TOKEN, apifyClient, randomString, getMockKVStore} = require('../helpers');
 const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
-
-const getMockKVStore = (storeName) => ({
-    id: randomString(),
-    name: storeName,
-    userId: randomString(),
-    username: randomString(),
-    createdAt: '2019-12-12T07:34:14.202Z',
-    modifiedAt: '2019-12-13T08:36:13.202Z',
-    accessedAt: '2019-12-14T08:36:13.202Z',
-    actId: null,
-    actRunId: null,
-    consoleUrl: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC',
-    stats: {
-        readCount: 9,
-        writeCount: 3,
-        deleteCount: 6,
-        listCount: 2,
-        s3StorageBytes: 18,
-    },
-});
 
 describe('set key-value store value', () => {
     afterEach(async () => {
@@ -54,7 +34,7 @@ describe('set key-value store value', () => {
 
         let scope;
         if (!TEST_USER_TOKEN) {
-            const mockKVStore = getMockKVStore(storeName);
+            const mockKVStore = getMockKVStore({ name: storeName });
             scope = nock('https://api.apify.com');
             scope.put(`/v2/key-value-stores/${mockKVStore.id}/records/${expectedKey}`, JSON.stringify(expectedValue))
                 .reply(201);

--- a/test/creates/set_value.js
+++ b/test/creates/set_value.js
@@ -1,13 +1,41 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
+const nock = require('nock');
 const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
 const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
+const getMockKVStore = (storeName) => ({
+    id: randomString(),
+    name: storeName,
+    userId: randomString(),
+    username: randomString(),
+    createdAt: '2019-12-12T07:34:14.202Z',
+    modifiedAt: '2019-12-13T08:36:13.202Z',
+    accessedAt: '2019-12-14T08:36:13.202Z',
+    actId: null,
+    actRunId: null,
+    consoleUrl: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC',
+    stats: {
+        readCount: 9,
+        writeCount: 3,
+        deleteCount: 6,
+        listCount: 2,
+        s3StorageBytes: 18,
+    },
+});
+
 describe('set key-value store value', () => {
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
     it('work for storeName', async () => {
+        const storeName = 'zapier-test';
         const expectedKey = randomString();
         const expectedValue = {
             myKey: randomString(),
@@ -17,11 +45,25 @@ describe('set key-value store value', () => {
                 access_token: TEST_USER_TOKEN,
             },
             inputData: {
-                storeIdOrName: 'zapier-test',
+                storeIdOrName: storeName,
                 key: expectedKey,
                 value: JSON.stringify(expectedValue),
             },
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockKVStore = getMockKVStore(storeName);
+            scope = nock('https://api.apify.com');
+            scope.put(`/v2/key-value-stores/${mockKVStore.id}/records/${expectedKey}`, JSON.stringify(expectedValue))
+                .reply(201);
+            scope.get(`/v2/key-value-stores/${storeName}`)
+                .reply(200, {
+                    data: mockKVStore,
+                });
+            scope.get(`/v2/key-value-stores/${mockKVStore.id}/records/${expectedKey}`)
+                .reply(200, expectedValue);
+        }
 
         const testResult = await appTester(App.creates.keyValueStoreSetValue.operation.perform, bundle);
 
@@ -29,14 +71,35 @@ describe('set key-value store value', () => {
 
         expect(expectedValue).to.be.eql(record.value);
         expect(testResult).to.include.all.keys(Object.keys(KEY_VALUE_STORE_SAMPLE));
+        scope?.done();
     }).timeout(10000);
 
     it('work for storeId', async () => {
-        const store = await apifyClient.keyValueStores().getOrCreate(`test-zapier-${randomString()}`);
+        const storeName = `test-zapier-${randomString()}`;
         const expectedKey = randomString();
         const expectedValue = {
             myKey: randomString(),
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockKVStore = getMockKVStore(storeName);
+            scope = nock('https://api.apify.com');
+            scope.post('/v2/key-value-stores')
+                .query({ name: storeName })
+                .reply(201, { data: mockKVStore });
+            scope.put(`/v2/key-value-stores/${mockKVStore.id}/records/${expectedKey}`, JSON.stringify(expectedValue))
+                .reply(201);
+            scope.get(`/v2/key-value-stores/${mockKVStore.id}`)
+                .reply(200, {
+                    data: mockKVStore,
+                });
+            scope.get(`/v2/key-value-stores/${mockKVStore.id}/records/${expectedKey}`)
+                .reply(200, expectedValue);
+        }
+
+        const store = await apifyClient.keyValueStores().getOrCreate(storeName);
+
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,
@@ -54,6 +117,10 @@ describe('set key-value store value', () => {
 
         expect(expectedValue).to.be.eql(record.value);
 
-        await apifyClient.keyValueStore(store.id).delete();
+        if (TEST_USER_TOKEN) {
+            await apifyClient.keyValueStore(store.id).delete();
+        }
+
+        scope?.done();
     }).timeout(10000);
 });

--- a/test/creates/set_value.js
+++ b/test/creates/set_value.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const _ = require('lodash');

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -1,26 +1,43 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const _ = require('lodash');
-const { TEST_USER_TOKEN, apifyClient, createWebScraperTask, createLegacyCrawlerTask } = require('../helpers');
-const { TASK_RUN_SAMPLE } = require('../../src/consts');
+const nock = require('nock');
+const { TEST_USER_TOKEN, apifyClient, createWebScraperTask, createLegacyCrawlerTask, randomString, getMockRun } = require('../helpers');
+const { TASK_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
 describe('create task run', () => {
-    let testTask1Id;
-    let testTask2Id;
-    let testTask3Id;
+    let testTask1Id = randomString();
+    let testTask2Id = randomString();
+    let testTask3Id = randomString();
 
     before(async () => {
-        // Create task for testing
-        const task1 = await createWebScraperTask();
-        testTask1Id = task1.id;
-        const task2 = await createWebScraperTask('() => ({ foo: "bar" })');
-        testTask2Id = task2.id;
-        const task3 = await createLegacyCrawlerTask('function pageFunction(context) { return { testedField: "testValue" } }');
-        testTask3Id = task3.id;
+        if (TEST_USER_TOKEN) {
+            // Create task for testing
+            const task1 = await createWebScraperTask();
+            testTask1Id = task1.id;
+            const task2 = await createWebScraperTask('() => ({ foo: "bar" })');
+            testTask2Id = task2.id;
+            const task3 = await createLegacyCrawlerTask('function pageFunction(context) { return { testedField: "testValue" } }');
+            testTask3Id = task3.id;
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await Promise.all(
+                [testTask1Id, testTask2Id, testTask3Id].map((taskId) => apifyClient.task(taskId).delete()),
+            );
+        }
     });
 
     it('runSync work', async () => {
@@ -42,6 +59,20 @@ describe('create task run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockRun = getMockRun({ actorTaskId: testTask1Id });
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/actor-tasks/${testTask1Id}/runs`, { startUrls: [{ url: urlToScrape }] })
+                .query({ waitForFinish: 120 })
+                .reply(201, { data: mockRun });
+            scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ url: urlToScrape }]);
+        }
+
         const testResult = await appTester(App.creates.createTaskRun.operation.perform, bundle);
 
         expect(testResult).to.have.any.keys(Object.keys(TASK_RUN_SAMPLE).concat(['isStatusMessageTerminal', 'statusMessage']));
@@ -50,6 +81,8 @@ describe('create task run', () => {
         expect(testResult.datasetItems.length).to.be.at.least(1);
         expect(testResult.datasetItems[0].url).be.eql(urlToScrape);
         expect(testResult.finishedAt).to.not.equal(null);
+
+        scope?.done();
     }).timeout(120000);
 
     it('runSync work without output', async () => {
@@ -63,12 +96,28 @@ describe('create task run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockRun = getMockRun({ actorTaskId: testTask2Id });
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/actor-tasks/${testTask2Id}/runs`)
+                .query({ waitForFinish: 120 })
+                .reply(201, { data: mockRun });
+            scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, { ...KEY_VALUE_STORE_SAMPLE, error: 'No output' });
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, []);
+        }
+
         const testResult = await appTester(App.creates.createTaskRun.operation.perform, bundle);
 
         expect(testResult.status).to.be.eql('SUCCEEDED');
         expect(testResult.OUTPUT).to.not.equal(null);
         expect(testResult.OUTPUT).to.have.property('error');
         expect(testResult.finishedAt).to.not.equal(null);
+
+        scope?.done();
     }).timeout(120000);
 
     it('runAsync work', async () => {
@@ -82,9 +131,27 @@ describe('create task run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockRun = getMockRun({ actorTaskId: testTask1Id, finishedAt: null });
+            delete mockRun.exitCode;
+            delete mockRun.consoleUrl;
+
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/actor-tasks/${testTask1Id}/runs`)
+                .reply(201, { data: mockRun });
+            scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ url: 'http://example.com' }]);
+        }
+
         const testResult = await appTester(App.creates.createTaskRun.operation.perform, bundle);
         expect(testResult).to.have.all.keys(_.without(Object.keys(TASK_RUN_SAMPLE), 'exitCode', 'consoleUrl'));
         expect(testResult.finishedAt).to.be.eql(null);
+
+        scope?.done();
     }).timeout(50000);
 
     it('run legacy crawler and return simplified items work', async () => {
@@ -98,13 +165,24 @@ describe('create task run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const mockRun = getMockRun({ actorTaskId: testTask3Id });
+
+            scope = nock('https://api.apify.com');
+            scope.post(`/v2/actor-tasks/${testTask3Id}/runs`)
+                .query({ waitForFinish: 120 })
+                .reply(201, { data: mockRun });
+            scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ testedField: 'testValue' }]);
+        }
+
         const testResult = await appTester(App.creates.createTaskRun.operation.perform, bundle);
         expect(testResult.datasetItems[0].testedField).be.eql('testValue');
-    }).timeout(240000);
 
-    after(async () => {
-        await Promise.all(
-            [testTask1Id, testTask2Id, testTask3Id].map((taskId) => apifyClient.task(taskId).delete()),
-        );
-    });
+        scope?.done();
+    }).timeout(240000);
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -263,6 +263,48 @@ const getMockWebhookResponse = (condition, requestUrl, overrides) => {
     };
 };
 
+const getMockActorDetails = (actorFieldsOverrides) => {
+    return {
+        id: randomString(),
+        userId: randomString(),
+        name: 'test-actor-name',
+        username: 'test-user-name',
+        description: 'test-description',
+        restartOnError: false,
+        isPublic: false,
+        createdAt: new Date().toISOString(),
+        modifiedAt: new Date().toISOString(),
+        stats: {},
+        versions: [],
+        isDeprecated: false,
+        deploymentKey: '',
+        title: 'Test Actor',
+        defaultRunOptions: {
+            build: 'latest',
+            timeoutSecs: 3600,
+            memoryMbytes: 512,
+        },
+        taggedBuilds: {
+            latest: {
+                buildId: randomString(),
+                buildNumber: '0.0.1',
+                finishedAt: new Date().toISOString(),
+            },
+        },
+        ...actorFieldsOverrides,
+    };
+};
+
+const getMockActorBuild = (overrideFields) => {
+    return {
+        id: randomString(),
+        actId: randomString(),
+        userId: randomString(),
+        buildNumber: '0.0.1',
+        ...overrideFields,
+    };
+};
+
 module.exports = {
     TEST_USER_TOKEN,
     randomString,
@@ -273,4 +315,6 @@ module.exports = {
     getMockRun,
     getMockWebhookResponse,
     getMockTaskRun,
+    getMockActorDetails,
+    getMockActorBuild,
 };

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,5 +1,8 @@
 const { ApifyClient } = require('apify-client');
 const zapier = require('zapier-platform-core');
+const { WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_STATUSES } = require('@apify/consts');
+const { getRandomInt } = require('@apify/utilities');
+const { ACTOR_RUN_SAMPLE, TASK_RUN_SAMPLE } = require('../../src/consts');
 
 const DEFAULT_PAGE_FUNCTION = `
 async function pageFunction({ request, setValue }) {
@@ -161,6 +164,105 @@ const createAndBuildActor = async () => {
     return actor;
 };
 
+const getMockRun = (overrides) => {
+    return {
+        id: randomString(),
+        actId: randomString(),
+        userId: randomString(),
+        startedAt: '2019-11-30T07:34:24.202Z',
+        finishedAt: '2019-12-12T09:30:12.202Z',
+        status: ACTOR_JOB_STATUSES.SUCCEEDED,
+        meta: {
+            origin: 'DEVELOPMENT',
+        },
+        stats: {
+            inputBodyLen: 240,
+            migrationCount: 0,
+            restartCount: 0,
+            resurrectCount: 2,
+            memAvgBytes: 267874071.9,
+            memMaxBytes: 404713472,
+            memCurrentBytes: 0,
+            cpuAvgUsage: 33.7532101107538,
+            cpuMaxUsage: 169.650735534941,
+            cpuCurrentUsage: 0,
+            netRxBytes: 103508042,
+            netTxBytes: 4854600,
+            durationMillis: 248472,
+            runTimeSecs: 248.472,
+            metamorph: 0,
+            computeUnits: 0.13804,
+        },
+        options: {
+            build: 'latest',
+            timeoutSecs: 300,
+            memoryMbytes: 1024,
+            diskMbytes: 2048,
+        },
+        buildId: '7sT5jcggjjA9fNcxF',
+        exitCode: 0,
+        defaultKeyValueStoreId: randomString(),
+        defaultDatasetId: randomString(),
+        defaultRequestQueueId: randomString(),
+        buildNumber: '0.0.36',
+        containerUrl: 'https://g8kd8kbc5ge8.runs.apify.net',
+        consoleUrl: 'https://console.apify.com/v2/actor/runs/1',
+        generalAccess: false,
+        usageTotalUsd: 0.2654,
+        usage: {},
+        usageUsd: {
+            ACTOR_COMPUTE_UNITS: 0.072,
+            DATASET_READS: 0.0004,
+            DATASET_WRITES: 0.0002,
+            KEY_VALUE_STORE_READS: 0.0006,
+            KEY_VALUE_STORE_WRITES: 0.002,
+            KEY_VALUE_STORE_LISTS: 0.004,
+            REQUEST_QUEUE_READS: 0.005,
+            REQUEST_QUEUE_WRITES: 0.02,
+            DATA_TRANSFER_INTERNAL_GBYTES: 0.0004,
+            PROXY_RESIDENTIAL_TRANSFER_GBYTES: 0.16,
+            PROXY_SERPS: 0.0006,
+        },
+        ...overrides,
+    };
+};
+
+const getMockTaskRun = (overrides) => {
+    return getMockRun({
+        actorTaskId: randomString(),
+        isStatusMessageTerminal: true,
+        statusMessage: 'Task Run Finished.',
+        ...overrides,
+    });
+};
+
+const getMockWebhookResponse = (condition, requestUrl, overrides) => {
+    return {
+        id: randomString(),
+        createdAt: '2019-12-12T07:34:14.202Z',
+        modifiedAt: '2019-12-13T08:36:13.202Z',
+        userId: randomString(),
+        isAdHoc: false,
+        shouldInterpolateStrings: false,
+        eventTypes: WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL,
+        condition,
+        ignoreSslErrors: false,
+        doNotRetry: false,
+        requestUrl,
+        payloadTemplate: '{\\n \\"userId\\": {{userId}}...',
+        headersTemplate: '{\\n \\"Authorization\\": Bearer...',
+        description: 'this is webhook description',
+        lastDispatch: {
+            status: 'SUCCEEDED',
+            finishedAt: '2019-12-13T08:36:13.202Z',
+        },
+        stats: {
+            totalDispatches: 1,
+        },
+        ...overrides,
+    };
+};
+
 module.exports = {
     TEST_USER_TOKEN,
     randomString,
@@ -168,4 +270,7 @@ module.exports = {
     createWebScraperTask,
     createAndBuildActor,
     createLegacyCrawlerTask,
+    getMockRun,
+    getMockWebhookResponse,
+    getMockTaskRun,
 };

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -305,6 +305,45 @@ const getMockActorBuild = (overrideFields) => {
     };
 };
 
+const getMockDataset = (overrides) => {
+    return {
+        id: randomString(),
+        name: randomString(),
+        userId: randomString(),
+        createdAt: '2019-12-12T07:34:14.202Z',
+        modifiedAt: '2019-12-13T08:36:13.202Z',
+        accessedAt: '2019-12-14T08:36:13.202Z',
+        itemCount: 5,
+        cleanItemCount: 5,
+        actId: null,
+        actRunId: null,
+        fields: [],
+        consoleUrl: `https://console.apify.com/storage/datasets/${randomString()}`,
+        ...overrides,
+    };
+};
+
+const getMockKVStore = (overrides) => ({
+    id: randomString(),
+    name: randomString(),
+    userId: randomString(),
+    username: randomString(),
+    createdAt: '2019-12-12T07:34:14.202Z',
+    modifiedAt: '2019-12-13T08:36:13.202Z',
+    accessedAt: '2019-12-14T08:36:13.202Z',
+    actId: null,
+    actRunId: null,
+    consoleUrl: 'https://console.apify.com/storage/key-value-stores/27TmTznX9YPeAYhkC',
+    stats: {
+        readCount: 9,
+        writeCount: 3,
+        deleteCount: 6,
+        listCount: 2,
+        s3StorageBytes: 18,
+    },
+    ...overrides,
+});
+
 module.exports = {
     TEST_USER_TOKEN,
     randomString,
@@ -317,4 +356,6 @@ module.exports = {
     getMockTaskRun,
     getMockActorDetails,
     getMockActorBuild,
+    getMockDataset,
+    getMockKVStore,
 };

--- a/test/searches/actor_last_run.js
+++ b/test/searches/actor_last_run.js
@@ -1,11 +1,12 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { expect } = require('chai');
-const { apifyClient, TEST_USER_TOKEN, createAndBuildActor, getMockRun} = require('../helpers');
+const nock = require('nock');
+const { apifyClient, TEST_USER_TOKEN, createAndBuildActor, getMockRun } = require('../helpers');
 
 const App = require('../../index');
-const nock = require("nock");
-const {KEY_VALUE_STORE_SAMPLE} = require("../../src/consts");
+const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 
 const appTester = zapier.createAppTester(App);
 

--- a/test/searches/actor_last_run.js
+++ b/test/searches/actor_last_run.js
@@ -1,20 +1,36 @@
 const zapier = require('zapier-platform-core');
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { expect } = require('chai');
-const { apifyClient, TEST_USER_TOKEN, createAndBuildActor } = require('../helpers');
+const { apifyClient, TEST_USER_TOKEN, createAndBuildActor, getMockRun} = require('../helpers');
 
 const App = require('../../index');
+const nock = require("nock");
+const {KEY_VALUE_STORE_SAMPLE} = require("../../src/consts");
 
 const appTester = zapier.createAppTester(App);
 
 describe('search actor last run', () => {
-    let testActorId;
+    let testActorId = 'test_actor-id';
 
     before(async function () {
-        this.timeout(120000); // We need time to build actor
-        // Create actor for testing
-        const actor = await createAndBuildActor();
-        testActorId = actor.id;
+        if (TEST_USER_TOKEN) {
+            this.timeout(120000); // We need time to build actor
+            // Create actor for testing
+            const actor = await createAndBuildActor();
+            testActorId = actor.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.actor(testActorId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('work for actor without run', async () => {
@@ -28,9 +44,19 @@ describe('search actor last run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get(`/v2/acts/${testActorId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.SUCCEEDED })
+                .reply(404, 'Run not found');
+        }
+
         const testResult = await appTester(App.searches.searchActorRun.operation.perform, bundle);
 
         expect(testResult.length).to.be.eql(0);
+
+        scope?.done();
     });
 
     it('work', async () => {
@@ -44,15 +70,32 @@ describe('search actor last run', () => {
             },
         };
 
-        const actorRun = await apifyClient.actor(testActorId).call({ waitSecs: 120 });
+        let actorRun;
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            actorRun = getMockRun();
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/acts/${testActorId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.SUCCEEDED })
+                .reply(200, {
+                    data: actorRun,
+                });
+
+            scope.get(`/v2/key-value-stores/${actorRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+        } else {
+            actorRun = await apifyClient.actor(testActorId).call({ waitSecs: 120 });
+        }
 
         const testResult = await appTester(App.searches.searchActorRun.operation.perform, bundle);
 
         expect(testResult[0].status).to.be.eql(ACTOR_JOB_STATUSES.SUCCEEDED);
         expect(testResult[0].id).to.be.eql(actorRun.id);
-    }).timeout(240000);
 
-    after(async () => {
-        await apifyClient.actor(testActorId).delete();
-    });
+        scope?.done();
+    }).timeout(240000);
 });

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -2,7 +2,7 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
-const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
+const { TEST_USER_TOKEN, apifyClient, randomString, getMockDataset} = require('../helpers');
 const { DATASET_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
@@ -10,7 +10,7 @@ const App = require('../../index');
 const appTester = zapier.createAppTester(App);
 
 describe('fetch dataset items', () => {
-    let testDatasetId = DATASET_SAMPLE.id;
+    let testDatasetId = randomString();
 
     before(async () => {
         if (TEST_USER_TOKEN) {
@@ -59,7 +59,7 @@ describe('fetch dataset items', () => {
             scope = nock('https://api.apify.com');
             scope.get(`/v2/datasets/${testDatasetId}`)
                 .reply(200, {
-                    data: DATASET_SAMPLE,
+                    data: getMockDataset({ id: testDatasetId, items: 1000, cleanItems: 1000 }),
                 });
             scope.get(`/v2/datasets/${testDatasetId}/items`)
                 .query({ limit: null, offset: null, clean: true })

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -1,5 +1,6 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
+const nock = require('nock');
 const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
 const { DATASET_SAMPLE } = require('../../src/consts');
 
@@ -7,13 +8,26 @@ const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
-
 describe('fetch dataset items', () => {
-    let testDatasetId;
+    let testDatasetId = DATASET_SAMPLE.id;
 
     before(async () => {
-        const dataset = await apifyClient.datasets().getOrCreate(`test-zapier-${randomString()}`);
-        testDatasetId = dataset.id;
+        if (TEST_USER_TOKEN) {
+            const dataset = await apifyClient.datasets().getOrCreate(`test-zapier-${randomString()}`);
+            testDatasetId = dataset.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.dataset(testDatasetId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('work', async () => {
@@ -24,8 +38,11 @@ describe('fetch dataset items', () => {
                 i,
             });
         }
-        // Push data to dataset
-        await apifyClient.dataset(testDatasetId).pushItems(randomItems);
+
+        if (TEST_USER_TOKEN) {
+            // Push data to dataset
+            await apifyClient.dataset(testDatasetId).pushItems(randomItems);
+        }
 
         const bundle = {
             authData: {
@@ -36,14 +53,24 @@ describe('fetch dataset items', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/datasets/${testDatasetId}`)
+                .reply(200, {
+                    data: DATASET_SAMPLE,
+                });
+            scope.get(`/v2/datasets/${testDatasetId}/items`)
+                .query({ limit: null, offset: null, clean: true })
+                .reply(200, randomItems);
+        }
+
         const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
 
         expect(testResult[0].items.length).to.be.eql(randomItems.length);
         expect(testResult[0]).to.include.all.keys(Object.keys(DATASET_SAMPLE));
         expect(testResult[0].itemsFileUrls).to.include.all.keys('xml', 'csv', 'json', 'xlsx', 'html', 'rss');
-    }).timeout(120000);
 
-    after(async () => {
-        await apifyClient.dataset(testDatasetId).delete();
-    });
+        scope?.done();
+    }).timeout(120000);
 });

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const nock = require('nock');
 
-const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
+const { TEST_USER_TOKEN, apifyClient, randomString, getMockKVStore} = require('../helpers');
 const App = require('../../index');
 const { KEY_VALUE_STORE_SAMPLE} = require('../../src/consts');
 
@@ -14,7 +14,7 @@ chai.use(chaiAsPromised);
 const appTester = zapier.createAppTester(App);
 
 describe('get key-value store value', () => {
-    let testStoreId = KEY_VALUE_STORE_SAMPLE.id;
+    let testStoreId = randomString();
 
     before(async () => {
         if (TEST_USER_TOKEN) {
@@ -64,8 +64,8 @@ describe('get key-value store value', () => {
         let scope;
         if (!TEST_USER_TOKEN) {
             scope = nock('https://api.apify.com');
-            scope.get(`/v2/key-value-stores/${TEST_USER_TOKEN}`)
-                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/key-value-stores/${testStoreId}`)
+                .reply(200, { data: getMockKVStore({ id: testStoreId }) });
             scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
                 .reply(200, storeValue);
         }
@@ -102,7 +102,7 @@ describe('get key-value store value', () => {
         if (!TEST_USER_TOKEN) {
             scope = nock('https://api.apify.com');
             scope.get(`/v2/key-value-stores/${testStoreId}`)
-                .reply(200, KEY_VALUE_STORE_SAMPLE);
+                .reply(200, { data: getMockKVStore({ id: testStoreId }) });
             scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
                 .reply(200, 'just text', {
                     'content-type': 'plain/text',
@@ -130,7 +130,7 @@ describe('get key-value store value', () => {
         if (!TEST_USER_TOKEN) {
             scope = nock('https://api.apify.com');
             scope.get(`/v2/key-value-stores/${testStoreId}`)
-                .reply(200, KEY_VALUE_STORE_SAMPLE);
+                .reply(200, { data: getMockKVStore({ id: testStoreId }) });
             scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
                 .reply(404);
         }

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -5,7 +6,7 @@ const nock = require('nock');
 
 const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
 const App = require('../../index');
-const { KEY_VALUE_STORE_SAMPLE, DATASET_SAMPLE} = require('../../src/consts');
+const { KEY_VALUE_STORE_SAMPLE} = require('../../src/consts');
 
 const { expect } = chai;
 chai.use(chaiAsPromised);

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -1,22 +1,38 @@
 const zapier = require('zapier-platform-core');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const nock = require('nock');
+
 const { TEST_USER_TOKEN, apifyClient, randomString } = require('../helpers');
+const App = require('../../index');
+const { KEY_VALUE_STORE_SAMPLE, DATASET_SAMPLE} = require('../../src/consts');
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
 
-const App = require('../../index');
-
 const appTester = zapier.createAppTester(App);
 
 describe('get key-value store value', () => {
-    let testStoreId;
+    let testStoreId = KEY_VALUE_STORE_SAMPLE.id;
 
     before(async () => {
-        // Create key-value store for testing
-        const store = await apifyClient.keyValueStores().getOrCreate(`test-zapier-${randomString()}`);
-        testStoreId = store.id;
+        if (TEST_USER_TOKEN) {
+            // Create key-value store for testing
+            const store = await apifyClient.keyValueStores().getOrCreate(`test-zapier-${randomString()}`);
+            testStoreId = store.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.keyValueStore(testStoreId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('work', async () => {
@@ -24,12 +40,15 @@ describe('get key-value store value', () => {
         const storeValue = {
             myKey: randomString(),
         };
-        // Create record
-        await apifyClient.keyValueStore(testStoreId).setRecord({
-            key: storeKey,
-            contentType: 'application/json',
-            value: JSON.stringify(storeValue),
-        });
+
+        if (TEST_USER_TOKEN) {
+            // Create record
+            await apifyClient.keyValueStore(testStoreId).setRecord({
+                key: storeKey,
+                contentType: 'application/json',
+                value: JSON.stringify(storeValue),
+            });
+        }
 
         const bundle = {
             authData: {
@@ -40,20 +59,33 @@ describe('get key-value store value', () => {
                 key: storeKey,
             },
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/key-value-stores/${TEST_USER_TOKEN}`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
+                .reply(200, storeValue);
+        }
 
         const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
 
         expect(storeValue).to.be.eql(testResult[0]);
+        scope?.done();
     }).timeout(10000);
 
     it('throw error for non json value', async () => {
         const storeKey = randomString();
-        // Create record
-        await apifyClient.keyValueStore(testStoreId).setRecord({
-            key: storeKey,
-            contentType: 'plain/text',
-            value: 'just text',
-        });
+
+        if (TEST_USER_TOKEN) {
+            // Create record
+            await apifyClient.keyValueStore(testStoreId).setRecord({
+                key: storeKey,
+                contentType: 'plain/text',
+                value: 'just text',
+            });
+        }
 
         const bundle = {
             authData: {
@@ -65,26 +97,45 @@ describe('get key-value store value', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/key-value-stores/${testStoreId}`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
+                .reply(200, 'just text', {
+                    'content-type': 'plain/text',
+                });
+        }
+
         await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle)).to.be.rejectedWith(/is not JSON object/);
+        scope?.done();
     }).timeout(10000);
 
     it('work for empty value', async () => {
+        const storeKey = randomString();
+
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,
             },
             inputData: {
                 storeIdOrName: testStoreId,
-                key: 'does-not-exist',
+                key: storeKey,
             },
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/key-value-stores/${testStoreId}`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
+                .reply(404);
+        }
 
         const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
 
         expect(testResult).to.be.eql([]);
     }).timeout(10000);
-
-    after(async () => {
-        await apifyClient.keyValueStore(testStoreId).delete();
-    });
 });

--- a/test/searches/task_last_run.js
+++ b/test/searches/task_last_run.js
@@ -1,19 +1,36 @@
 const zapier = require('zapier-platform-core');
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { expect } = require('chai');
-const { apifyClient, createWebScraperTask, TEST_USER_TOKEN } = require('../helpers');
+const nock = require('nock');
+const { apifyClient, createWebScraperTask, TEST_USER_TOKEN, getMockTaskRun } = require('../helpers');
 
 const App = require('../../index');
+const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 
 const appTester = zapier.createAppTester(App);
 
 describe('search task last run', () => {
-    let testTaskId;
+    let testTaskId = 'test_task-id';
 
     before(async () => {
-        // Create task for testing
-        const task = await createWebScraperTask();
-        testTaskId = task.id;
+        if (TEST_USER_TOKEN) {
+            this.timeout(120000); // We need time to build actor
+            // Create task for testing
+            const task = await createWebScraperTask();
+            testTaskId = task.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.task(testTaskId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('work for task without run', async () => {
@@ -27,9 +44,18 @@ describe('search task last run', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get(`/v2/actor-tasks/${testTaskId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.SUCCEEDED })
+                .reply(404, 'Run not found');
+        }
+
         const testResult = await appTester(App.searches.searchTaskRun.operation.perform, bundle);
 
         expect(testResult.length).to.be.eql(0);
+        scope?.done();
     }).timeout(240000);
 
     it('work', async () => {
@@ -43,14 +69,33 @@ describe('search task last run', () => {
             },
         };
 
-        const taskRun = await apifyClient.task(testTaskId).call({
-            waitSecs: 120,
-        });
+        let taskRun;
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            taskRun = getMockTaskRun();
+
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/actor-tasks/${testTaskId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.SUCCEEDED })
+                .reply(200, taskRun);
+
+            scope.get(`/v2/key-value-stores/${taskRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+
+            scope.get(`/v2/datasets/${taskRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+        } else {
+            taskRun = await apifyClient.task(testTaskId).call({
+                waitSecs: 120,
+            });
+        }
 
         const testResult = await appTester(App.searches.searchTaskRun.operation.perform, bundle);
 
         expect(testResult[0].status).to.be.eql(ACTOR_JOB_STATUSES.SUCCEEDED);
         expect(testResult[0].id).to.be.eql(taskRun.id);
+        scope?.done();
     }).timeout(240000);
 
     it('return empty array if there is no run with status', async () => {
@@ -60,16 +105,21 @@ describe('search task last run', () => {
             },
             inputData: {
                 taskId: testTaskId,
-                status: 'TIMING-OUT',
+                status: ACTOR_JOB_STATUSES.TIMING_OUT,
             },
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get(`/v2/actor-tasks/${testTaskId}/runs/last`)
+                .query({ status: ACTOR_JOB_STATUSES.TIMING_OUT })
+                .reply(404, 'Run not found');
+        }
 
         const testResult = await appTester(App.searches.searchTaskRun.operation.perform, bundle);
 
         expect(testResult.length).to.be.eql(0);
-    });
-
-    after(async () => {
-        await apifyClient.task(testTaskId).delete();
+        scope?.done();
     });
 });

--- a/test/searches/task_last_run.js
+++ b/test/searches/task_last_run.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { expect } = require('chai');
@@ -12,7 +13,7 @@ const appTester = zapier.createAppTester(App);
 describe('search task last run', () => {
     let testTaskId = 'test_task-id';
 
-    before(async () => {
+    before(async function () {
         if (TEST_USER_TOKEN) {
             this.timeout(120000); // We need time to build actor
             // Create task for testing

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
@@ -187,7 +188,7 @@ describe('actor run finished trigger', () => {
         const results = await appTester(App.triggers.actorRunFinished.operation.performList, bundle);
 
         expect(results.length).to.be.eql(3);
-        expect(results.map((item) => item.id)).to.eql(runs.slice(0, 3).map((run) => run.id));
+        expect(results.every((item) => runs.some((run) => run.id === item.id))).to.eql(true);
         expect(results[0]).to.have.all.keys({ ...ACTOR_RUN_SAMPLE, consoleUrl: '' });
         expect(results[0].OUTPUT).to.not.equal(null);
         expect(results[0].datasetItems.length).to.be.at.least(1);
@@ -197,6 +198,12 @@ describe('actor run finished trigger', () => {
     }).timeout(240000);
 
     describe('actors hidden trigger', () => {
+        afterEach(async () => {
+            if (!TEST_USER_TOKEN) {
+                nock.cleanAll();
+            }
+        });
+
         it('work', async () => {
             const bundle = {
                 authData: {

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -4,8 +4,8 @@ const { expect } = require('chai');
 const nock = require('nock');
 const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
 
-const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse} = require('../helpers');
-const { ACTOR_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
+const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse } = require('../helpers');
+const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
 
@@ -177,7 +177,7 @@ describe('actor run finished trigger', () => {
                     .reply(200, { data: run });
 
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
-                    .reply(200, KEY_VALUE_STORE_SAMPLE);
+                    .reply(200, { foo: 'bar' });
 
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -1,21 +1,38 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
-const _ = require('lodash');
-const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString } = require('../helpers');
-const { ACTOR_RUN_SAMPLE} = require('../../src/consts');
+const nock = require('nock');
+const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
+
+const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse} = require('../helpers');
+const { ACTOR_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
+
 const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
 describe('actor run finished trigger', () => {
-    let testActorId;
+    let testActorId = randomString();
     let subscribeData;
 
     before(async function () {
-        this.timeout(120000); // We need time to build actor
-        // Create actor for testing
-        const actor = await createAndBuildActor();
-        testActorId = actor.id;
+        if (TEST_USER_TOKEN) {
+            this.timeout(120000); // We need time to build actor
+            // Create actor for testing
+            const actor = await createAndBuildActor();
+            testActorId = actor.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.actor(testActorId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('subscribe webhook work', async () => {
@@ -23,23 +40,44 @@ describe('actor run finished trigger', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                access_token: TEST_USER_TOKEN,
+                access_token: TEST_USER_TOKEN ?? 'test-token',
             },
             inputData: {
                 actorId: testActorId,
             },
             meta: {},
         };
+
+        let scope;
+
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .post('/v2/webhooks', (payload) => {
+                    expect(payload).to.have.property('requestUrl', requestUrl);
+                    expect(payload).to.have.property('eventTypes')
+                        .that.includes.members(WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL);
+                    expect(payload).to.have.property('condition').that.has.property('actorId', testActorId);
+                    return true;
+                })
+                .query(true)
+                // Mock the response here as it is used in other tests. It's not ideal as we want to have our tests independent of each other,
+                .reply(201, getMockWebhookResponse(testActorId, requestUrl));
+        }
+
         subscribeData = await appTester(App.triggers.actorRunFinished.operation.performSubscribe, bundle);
 
-        // Check if webhook is set
-        const actorWebhooks = await apifyClient.actor(testActorId).webhooks().list();
+        if (TEST_USER_TOKEN) {
+            // Check if webhook is set
+            const actorWebhooks = await apifyClient.actor(testActorId).webhooks().list();
 
-        expect(actorWebhooks.items.length).to.be.eql(1);
-        expect(actorWebhooks.items[0].requestUrl).to.be.eql(requestUrl);
-        expect(actorWebhooks.items[0].eventTypes)
-            .to.include.members(['ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED', 'ACTOR.RUN.TIMED_OUT', 'ACTOR.RUN.ABORTED'])
-            .but.not.include.members(['ACTOR.RUN.CREATED']);
+            expect(actorWebhooks.items.length).to.be.eql(1);
+            expect(actorWebhooks.items[0].requestUrl).to.be.eql(requestUrl);
+            expect(actorWebhooks.items[0].eventTypes)
+                .to.include.members(['ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED', 'ACTOR.RUN.TIMED_OUT', 'ACTOR.RUN.ABORTED'])
+                .but.not.include.members(['ACTOR.RUN.CREATED']);
+        } else {
+            scope.done();
+        }
     });
 
     it('unsubscribe webhook work', async () => {
@@ -50,12 +88,25 @@ describe('actor run finished trigger', () => {
             subscribeData,
             meta: {},
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .delete(`/v2/webhooks/${subscribeData.id}`)
+                .query(true)
+                .reply(204);
+        }
+
         await appTester(App.triggers.actorRunFinished.operation.performUnsubscribe, bundle);
 
-        // Check if webhook is not set
-        const actorWebhooks = await apifyClient.actor(testActorId).webhooks().list();
+        if (TEST_USER_TOKEN) {
+            // Check if webhook is not set
+            const actorWebhooks = await apifyClient.actor(testActorId).webhooks().list();
 
-        expect(actorWebhooks.items.length).to.be.eql(0);
+            expect(actorWebhooks.items.length).to.be.eql(0);
+        } else {
+            scope.done();
+        }
     });
 
     it('perform should return actor run detail', async () => {
@@ -82,12 +133,16 @@ describe('actor run finished trigger', () => {
 
     it('performList should return actor runs', async () => {
         const runs = [];
-        for (let i = 0; i < 4; i++) {
-            const run = await apifyClient.actor(testActorId).call({
-                waitSecs: 120,
-            });
-            runs.push(run);
+
+        if (TEST_USER_TOKEN) {
+            for (let i = 0; i < 4; i++) {
+                const run = await apifyClient.actor(testActorId).call({
+                    waitSecs: 120,
+                });
+                runs.push(run);
+            }
         }
+
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,
@@ -97,14 +152,48 @@ describe('actor run finished trigger', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            runs.push(getMockRun());
+            runs.push(getMockRun());
+            runs.push(getMockRun());
+            runs.push(getMockRun());
+
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/acts/${testActorId}/runs`)
+                .query({ limit: 100, desc: true })
+                .reply(200, {
+                    data: {
+                        items: runs.map((run) => {
+                            return { id: run.id, status: run.status };
+                        }),
+                    },
+                });
+
+            runs.slice(0, 3).forEach((run) => {
+                scope.get(`/v2/acts/${testActorId}/runs/${run.id}`)
+                    .query(true)
+                    .reply(200, { data: run });
+
+                scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
+                    .reply(200, KEY_VALUE_STORE_SAMPLE);
+
+                scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                    .query({ limit: 100, clean: true })
+                    .reply(200, [{ foo: 'bar' }]);
+            });
+        }
+
         const results = await appTester(App.triggers.actorRunFinished.operation.performList, bundle);
 
         expect(results.length).to.be.eql(3);
-        expect(results[0].id).to.be.eql(runs.pop().id);
+        expect(results.map((item) => item.id)).to.eql(runs.slice(0, 3).map((run) => run.id));
         expect(results[0]).to.have.all.keys({ ...ACTOR_RUN_SAMPLE, consoleUrl: '' });
         expect(results[0].OUTPUT).to.not.equal(null);
         expect(results[0].datasetItems.length).to.be.at.least(1);
         expect(results[0].datasetItemsFileUrls).to.include.all.keys('xml', 'csv', 'json', 'xlsx');
+
+        scope?.done();
     }).timeout(240000);
 
     describe('actors hidden trigger', () => {
@@ -117,14 +206,35 @@ describe('actor run finished trigger', () => {
                 meta: {},
             };
 
+            let scope;
+            if (!TEST_USER_TOKEN) {
+                scope = nock('https://api.apify.com')
+                    .get('/v2/acts')
+                    .query({ limit: 500, offset: 0 })
+                    .reply(200, {
+                        data: {
+                            total: 1,
+                            offset: 0,
+                            limit: 500,
+                            desc: false,
+                            count: 1,
+                            items: [{
+                                id: testActorId,
+                                name: 'test-actor-name',
+                                username: 'test-user-id',
+                                createdAt: new Date().toISOString(),
+                                modifiedAt: new Date().toISOString(),
+                            }],
+                        },
+                    });
+            }
+
             const actorList = await appTester(App.triggers.actors.operation.perform, bundle);
 
             expect(actorList.length).to.be.at.least(1);
             actorList.forEach((actor) => expect(actor).to.have.all.keys('id', 'name'));
-        });
-    });
 
-    after(async () => {
-        await apifyClient.actor(testActorId).delete();
+            scope?.done();
+        });
     });
 });

--- a/test/triggers/create_webhook_with_status.js
+++ b/test/triggers/create_webhook_with_status.js
@@ -23,7 +23,7 @@ describe('actor and task webhook creation', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: testToken,
+                access_token: testToken,
             },
             inputData: {
                 actorId: testActorId,
@@ -44,7 +44,7 @@ describe('actor and task webhook creation', () => {
                     ]);
                 return true;
             })
-            .query(true)
+            .matchHeader('x-apify-integration-platform', 'zapier')
             .reply(201, {});
 
         await appTester(App.triggers.actorRunFinished.operation.performSubscribe, bundle);
@@ -56,7 +56,7 @@ describe('actor and task webhook creation', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: testToken,
+                access_token: testToken,
             },
             inputData: {
                 taskId: testTaskId,
@@ -78,7 +78,7 @@ describe('actor and task webhook creation', () => {
                     ]);
                 return true;
             })
-            .query(true)
+            .matchHeader('x-apify-integration-platform', 'zapier')
             .reply(201, {});
 
         await appTester(App.triggers.taskRunFinished.operation.performSubscribe, bundle);
@@ -90,7 +90,7 @@ describe('actor and task webhook creation', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: testToken,
+                access_token: testToken,
             },
             inputData: {
                 actorId: testActorId,
@@ -112,7 +112,7 @@ describe('actor and task webhook creation', () => {
                     ]);
                 return true;
             })
-            .query(true)
+            .matchHeader('x-apify-integration-platform', 'zapier')
             .reply(201, {});
 
         await appTester(App.triggers.actorRunFinished.operation.performSubscribe, bundle);
@@ -124,7 +124,7 @@ describe('actor and task webhook creation', () => {
         const bundle = {
             targetUrl: requestUrl,
             authData: {
-                token: testToken,
+                access_token: testToken,
             },
             inputData: {
                 actorId: testActorId,
@@ -141,7 +141,7 @@ describe('actor and task webhook creation', () => {
                     .that.includes(...WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL);
                 return true;
             })
-            .query(true)
+            .matchHeader('x-apify-integration-platform', 'zapier')
             .reply(201, {});
 
         await appTester(App.triggers.actorRunFinished.operation.performSubscribe, bundle);

--- a/test/triggers/create_webhook_with_status.js
+++ b/test/triggers/create_webhook_with_status.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');

--- a/test/triggers/create_webhook_with_status.js
+++ b/test/triggers/create_webhook_with_status.js
@@ -2,10 +2,10 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
-const { WEBHOOK_EVENT_TYPES, WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_STATUSES} = require('@apify/consts');
+const { WEBHOOK_EVENT_TYPES, WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
 
 const App = require('../../index');
-const {randomString } = require('../helpers');
+const { randomString } = require('../helpers');
 
 const appTester = zapier.createAppTester(App);
 

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -3,10 +3,11 @@ const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
 const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
-const { randomString, apifyClient, createWebScraperTask,
+const { TASK_RUN_SAMPLE} = require('../../src/consts');
+const {
+    randomString, apifyClient, createWebScraperTask,
     TEST_USER_TOKEN, createLegacyCrawlerTask, getMockWebhookResponse, getMockTaskRun,
 } = require('../helpers');
-const { TASK_RUN_SAMPLE} = require('../../src/consts');
 
 const App = require('../../index');
 

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
@@ -201,7 +202,7 @@ describe('task run finished trigger', () => {
         const results = await appTester(App.triggers.taskRunFinished.operation.performList, bundle);
 
         expect(results.length).to.be.eql(3);
-        expect(results.map((result) => result.id)).to.be.eql(runs.slice(0, 3).map((run) => run.id));
+        expect(results.every((item) => runs.some((run) => run.id === item.id))).to.eql(true);
         expect(results[0]).to.have.all.keys(Object.keys(TASK_RUN_SAMPLE).concat(['isStatusMessageTerminal', 'statusMessage']));
         expect(results[0].OUTPUT).to.not.equal(null);
         expect(results[0].datasetItems.length).to.be.at.least(1);
@@ -239,6 +240,12 @@ describe('task run finished trigger', () => {
     }
 
     describe('tasks hidden trigger', () => {
+        afterEach(async () => {
+            if (!TEST_USER_TOKEN) {
+                nock.cleanAll();
+            }
+        });
+
         it('work', async () => {
             const bundle = {
                 authData: {

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -1,27 +1,44 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
+const nock = require('nock');
+const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
 const { randomString, apifyClient, createWebScraperTask,
-    TEST_USER_TOKEN, createLegacyCrawlerTask } = require('../helpers');
-const { TASK_RUN_SAMPLE } = require('../../src/consts');
+    TEST_USER_TOKEN, createLegacyCrawlerTask, getMockWebhookResponse, getMockTaskRun,
+} = require('../helpers');
+const { TASK_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
 
 const appTester = zapier.createAppTester(App);
 
-
 describe('task run finished trigger', () => {
     const testedResult = { testedField: 'testValue', url: 'https://apify.com' };
-    let testTaskId;
-    let legacyCrawlerTaskId;
+    let testTaskId = randomString();
+    let legacyCrawlerTaskId = randomString();
     let subscribeData;
 
     before(async function () {
-        this.timeout(120000);
-        // Create task for testing
-        const task = await createWebScraperTask();
-        testTaskId = task.id;
-        const legacyCrawlerTask = await createLegacyCrawlerTask(`function pageFunction(context) { return ${JSON.stringify(testedResult)} }`);
-        legacyCrawlerTaskId = legacyCrawlerTask.id;
+        if (TEST_USER_TOKEN) {
+            this.timeout(120000);
+            // Create task for testing
+            const task = await createWebScraperTask();
+            testTaskId = task.id;
+            const legacyCrawlerTask = await createLegacyCrawlerTask(`function pageFunction(context) { return ${JSON.stringify(testedResult)} }`);
+            legacyCrawlerTaskId = legacyCrawlerTask.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.task(testTaskId).delete();
+            await apifyClient.task(legacyCrawlerTaskId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
     });
 
     it('subscribe webhook work', async () => {
@@ -36,17 +53,34 @@ describe('task run finished trigger', () => {
             },
             meta: {},
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .post('/v2/webhooks', (payload) => {
+                    expect(payload).to.have.property('requestUrl', requestUrl);
+                    expect(payload).to.have.property('eventTypes')
+                        .that.includes.members(WEBHOOK_EVENT_TYPE_GROUPS.ACTOR_RUN_TERMINAL);
+                    expect(payload).to.have.property('condition').that.has.property('actorTaskId', testTaskId);
+                    return true;
+                })
+                .reply(200, getMockWebhookResponse());
+        }
+
         subscribeData = await appTester(App.triggers.taskRunFinished.operation.performSubscribe, bundle);
 
-        // Check if webhook is set
-        const taskWebhooks = await apifyClient.task(testTaskId).webhooks().list();
+        if (TEST_USER_TOKEN) {
+            // Check if webhook is set
+            const taskWebhooks = await apifyClient.task(testTaskId).webhooks().list();
 
-        expect(taskWebhooks.items.length).to.be.eql(1);
-        expect(taskWebhooks.items[0].requestUrl).to.be.eql(requestUrl);
-        expect(taskWebhooks.items[0].eventTypes)
-            .to.include.members(['ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED','ACTOR.RUN.TIMED_OUT', 'ACTOR.RUN.ABORTED'])
-            .but.not.include.members(['ACTOR.RUN.CREATED']);
-
+            expect(taskWebhooks.items.length).to.be.eql(1);
+            expect(taskWebhooks.items[0].requestUrl).to.be.eql(requestUrl);
+            expect(taskWebhooks.items[0].eventTypes)
+                .to.include.members(['ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED', 'ACTOR.RUN.TIMED_OUT', 'ACTOR.RUN.ABORTED'])
+                .but.not.include.members(['ACTOR.RUN.CREATED']);
+        } else {
+            scope.done();
+        }
     }).timeout(120000);
 
     it('unsubscribe webhook work', async () => {
@@ -57,12 +91,24 @@ describe('task run finished trigger', () => {
             subscribeData,
             meta: {},
         };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .delete(`/v2/webhooks/${subscribeData.id}`)
+                .reply(204);
+        }
+
         await appTester(App.triggers.taskRunFinished.operation.performUnsubscribe, bundle);
 
-        // Check if webhook is not set
-        const taskWebhooks = await apifyClient.task(testTaskId).webhooks().list();
+        if (TEST_USER_TOKEN) {
+            // Check if webhook is not set
+            const taskWebhooks = await apifyClient.task(testTaskId).webhooks().list();
 
-        expect(taskWebhooks.items.length).to.be.eql(0);
+            expect(taskWebhooks.items.length).to.be.eql(0);
+        } else {
+            scope.done();
+        }
     });
 
     it('perform should return task run detail', async () => {
@@ -89,11 +135,19 @@ describe('task run finished trigger', () => {
 
     it('performList should return task runs', async () => {
         const runs = [];
-        for (let i = 0; i < 4; i++) {
-            const run = await apifyClient.task(testTaskId).call({
-                waitSecs: 120,
-            });
-            runs.push(run);
+
+        if (TEST_USER_TOKEN) {
+            for (let i = 0; i < 4; i++) {
+                const run = await apifyClient.task(testTaskId).call({
+                    waitSecs: 120,
+                });
+                runs.push(run);
+            }
+        } else {
+            runs.push(getMockTaskRun());
+            runs.push(getMockTaskRun());
+            runs.push(getMockTaskRun());
+            runs.push(getMockTaskRun());
         }
 
         const bundle = {
@@ -105,40 +159,84 @@ describe('task run finished trigger', () => {
             },
         };
 
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/actor-tasks/${testTaskId}`)
+                .reply(200, {
+                    data: {
+                        id: testTaskId,
+                        userId: 'test-user-id',
+                        actId: 'random-actor-id',
+                        name: 'test-task-name',
+                        username: 'test-username',
+                        createdAt: new Date().toISOString(),
+                        modifiedAt: new Date().toISOString(),
+                    },
+                });
+            scope.get(`/v2/actor-tasks/${testTaskId}/runs`)
+                .query({ limit: 100, desc: true })
+                .reply(200, {
+                    data: {
+                        items: runs.map((run) => {
+                            return { id: run.id, status: run.status };
+                        }),
+                    },
+                });
+
+            runs.slice(0, 3).forEach((run) => {
+                scope.get(`/v2/acts/random-actor-id/runs/${run.id}`)
+                    .query(true)
+                    .reply(200, run);
+
+                scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
+                    .reply(200, KEY_VALUE_STORE_SAMPLE);
+
+                scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                    .query({ limit: 100, clean: true })
+                    .reply(200, [{ foo: 'bar' }]);
+            });
+        }
+
         const results = await appTester(App.triggers.taskRunFinished.operation.performList, bundle);
 
         expect(results.length).to.be.eql(3);
-        expect(results[0].id).to.be.eql(runs.pop().id);
+        expect(results.map((result) => result.id)).to.be.eql(runs.slice(0, 3).map((run) => run.id));
         expect(results[0]).to.have.all.keys(Object.keys(TASK_RUN_SAMPLE).concat(['isStatusMessageTerminal', 'statusMessage']));
         expect(results[0].OUTPUT).to.not.equal(null);
         expect(results[0].datasetItems.length).to.be.at.least(1);
         expect(results[0].datasetItemsFileUrls).to.include.all.keys('xml', 'csv', 'json', 'xlsx');
+
+        scope?.done();
     }).timeout(180000);
 
-    it('performList should return task runs (legacy crawler)', async () => {
-        // Create on task run
-        const taskRun = await apifyClient.task(legacyCrawlerTaskId).call({
-            waitSecs: 120,
-        });
+    // No need to run this test with mocks, it would just end up being a copy of the previous one
+    if (TEST_USER_TOKEN) {
+        it('performList should return task runs (legacy crawler)', async () => {
+            // Create on task run
+            const taskRun = await apifyClient.task(legacyCrawlerTaskId).call({
+                waitSecs: 120,
+            });
 
-        const bundle = {
-            authData: {
-                access_token: TEST_USER_TOKEN,
-            },
-            inputData: {
-                taskId: legacyCrawlerTaskId,
-            },
-        };
+            const bundle = {
+                authData: {
+                    access_token: TEST_USER_TOKEN,
+                },
+                inputData: {
+                    taskId: legacyCrawlerTaskId,
+                },
+            };
 
-        const results = await appTester(App.triggers.taskRunFinished.operation.performList, bundle);
+            const results = await appTester(App.triggers.taskRunFinished.operation.performList, bundle);
 
-        expect(results.length).to.be.eql(1);
-        expect(results[0].id).to.be.eql(taskRun.id);
-        expect(results[0]).to.have.all.keys(Object.keys(TASK_RUN_SAMPLE));
-        expect(results[0].datasetItems.length).to.be.at.least(1);
-        expect(results[0].datasetItems[0]).to.be.eql(testedResult);
-        expect(results[0].datasetItemsFileUrls).to.include.all.keys('xml', 'csv', 'json', 'xlsx');
-    }).timeout(120000);
+            expect(results.length).to.be.eql(1);
+            expect(results[0].id).to.be.eql(taskRun.id);
+            expect(results[0]).to.have.all.keys(Object.keys(TASK_RUN_SAMPLE));
+            expect(results[0].datasetItems.length).to.be.at.least(1);
+            expect(results[0].datasetItems[0]).to.be.eql(testedResult);
+            expect(results[0].datasetItemsFileUrls).to.include.all.keys('xml', 'csv', 'json', 'xlsx');
+        }).timeout(120000);
+    }
 
     describe('tasks hidden trigger', () => {
         it('work', async () => {
@@ -150,15 +248,35 @@ describe('task run finished trigger', () => {
                 meta: {},
             };
 
+            let scope;
+            if (!TEST_USER_TOKEN) {
+                scope = nock('https://api.apify.com')
+                    .get('/v2/actor-tasks')
+                    .query({ limit: 500, offset: 0 })
+                    .reply(200, {
+                        data: {
+                            total: 1,
+                            offset: 0,
+                            limit: 500,
+                            desc: false,
+                            count: 1,
+                            items: [{
+                                id: testTaskId,
+                                name: 'test-task-name',
+                                username: 'test-user-id',
+                                createdAt: new Date().toISOString(),
+                                modifiedAt: new Date().toISOString(),
+                            }],
+                        },
+                    });
+            }
+
             const taskList = await appTester(App.triggers.tasks.operation.perform, bundle);
 
             expect(taskList.length).to.be.at.least(1);
             taskList.forEach((task) => expect(task).to.have.all.keys('id', 'name'));
-        });
-    });
 
-    after(async () => {
-        await apifyClient.task(testTaskId).delete();
-        await apifyClient.task(legacyCrawlerTaskId).delete();
+            scope?.done();
+        });
     });
 });

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -6,7 +6,7 @@ const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
 const { randomString, apifyClient, createWebScraperTask,
     TEST_USER_TOKEN, createLegacyCrawlerTask, getMockWebhookResponse, getMockTaskRun,
 } = require('../helpers');
-const { TASK_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
+const { TASK_RUN_SAMPLE} = require('../../src/consts');
 
 const App = require('../../index');
 
@@ -191,7 +191,7 @@ describe('task run finished trigger', () => {
                     .reply(200, run);
 
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
-                    .reply(200, KEY_VALUE_STORE_SAMPLE);
+                    .reply(200, { foo: 'bar' });
 
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })

--- a/test/zapier_helpers.js
+++ b/test/zapier_helpers.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const { expect } = require('chai');
 const { convertPlainObjectToFieldSchema } = require('../src/zapier_helpers');
 


### PR DESCRIPTION
Implements the improvements to test suite suggested in #60.

The request mocking is used when the `TEST_USER_TOKEN` environment variable is not set.

To start mocked tests:
```bash
npm run test
```

And to start E2E tests with platform:
```bash
TEST_USER_TOKEN=test-token npm run test
```

I have also create new GitHub job to run the tests in both states. Since this PR doesn't change production code I felt like there is no need to increment the version and update `CHANGELOG.md`.