### PR TITLE
fix #49: obtaining text/plain

### DIFF
--- a/src/searches/get_value.js
+++ b/src/searches/get_value.js
@@ -52,7 +52,7 @@ const getValue = async (z, bundle) => {
         if (typeof response.data === 'object' && !Array.isArray(response.data) && response.data !== null) {
             data = response.data;
         } else {
-            data = { value: response.content ?? null };
+            data = { value: (response.data || response.content) ?? null };
         }
     } else {
         // There is a hard limit of 150MB on the size of dehydrated files.


### PR DESCRIPTION
We obtained value  from `response.data` previously, but it happens, that if content type is `text/plain`, that value is undefined, but `response.content` has the information. JSONs are parsed correctly with this approach as well. Version 4.2.2 has the change.