### PR TITLE
feat: Add GH Workflow for publishing the app to Zapier

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,92 @@
+name: Release & Publish Apify on Zapier
+on:
+    release:
+        types: [published]
+
+jobs:
+    setup_and_test:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
+
+            - name: Install Zapier CLI
+              run: npm install -g zapier-platform-cli
+
+            - name: Create .zapierrc file
+              run: |
+                  echo '{ "deployKey": "${{ secrets.APIFY_ZAPIER_DEPLOY_KEY }}" }' > ~/.zapierrc
+
+            - name: Install dependencies
+              run: npm install --no-audit
+
+            - name: Validate Zapier app
+              run: zapier validate --without-style
+
+            - name: Run lint
+              run: npm run lint
+
+            - name: Run tests
+              run: npm run test
+              env:
+                  TEST_USER_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
+
+            - name: Configure git
+              run: |
+                  git config --global user.name "Apify Release Bot"
+                  git config --global user.email "noreply@apify.com"
+
+            - name: Extract release version
+              id: get_version
+              run: |
+                  FULL_TAG_NAME="${{ github.event.release.tag_name }}"
+                  VERSION_NUMBER="${FULL_TAG_NAME#v}"
+                  echo "VERSION=${VERSION_NUMBER}" >> $GITHUB_ENV
+
+            - name: Bump package.json version
+              run: |
+                  echo "Updating package.json version to ${{ env.VERSION }}"
+                  npm version ${{ env.VERSION }} --no-git-tag-version
+
+            - name: Update CHANGELOG.md
+              run: |
+                  if [ -n "${{ github.event.release.body }}" ]; then
+                    echo "${{ github.event.release.body }}" >> temp_changelog.md
+                    echo "" >> temp_changelog.md
+
+                    # Prepend to existing CHANGELOG.md
+                    if [ -f CHANGELOG.md ]; then
+                      cat CHANGELOG.md >> temp_changelog.md
+                    fi
+
+                    # Replace the original CHANGELOG.md with the new one
+                    mv temp_changelog.md CHANGELOG.md
+                  fi
+
+            - name: Commit changes
+              run: |
+                  git add package.json package-lock.json CHANGELOG.md
+                  if ! git diff --staged --quiet; then
+                      TARGET_BRANCH="${{ github.event.release.target_commitish }}"
+                      echo "Target branch for push: $TARGET_BRANCH"
+                      git commit -m "chore(release): set version to ${{ env.VERSION }}"
+                      echo "Pushing changes to $TARGET_BRANCH"
+                      git push origin HEAD:"refs/heads/$TARGET_BRANCH"
+                  else
+                      echo "No changes to commit."
+                  fi
+              env:
+                  GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+            - name: Push Zapier app
+              run: zapier push
+
+            - name: Promote new version
+              run: zapier promote --yes ${{ env.VERSION }}


### PR DESCRIPTION
Links to #11.

Creates a GitHub Workflow which is run when new version is released on GitHub.

The main goal of the workflow is to validate the release and push it to Zapier. I have tested the workflow using a test app. Here is the link to the final job: https://github.com/matyascimbulka/zapier-test-app/actions/runs/16115286659/job/45467679419#step:16:53

It still fails but only on the final step and because my app isn't setup properly.