### PR TITLE
feat: Improve getting runs with multiple statuses

### DIFF
--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -2,7 +2,7 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
-const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
+const { WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_TERMINAL_STATUSES } = require('@apify/consts');
 
 const _ = require('lodash');
 const { ActorListSortBy } = require('apify-client');
@@ -166,7 +166,7 @@ describe('actor run finished trigger', () => {
 
             scope = nock('https://api.apify.com');
             scope.get(`/v2/acts/${testActorId}/runs`)
-                .query({ limit: 100, desc: true })
+                .query({ limit: 100, desc: true, status: ACTOR_JOB_TERMINAL_STATUSES.join(',') })
                 .reply(200, {
                     data: {
                         items: runs.map((run) => {

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -2,7 +2,7 @@
 const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const nock = require('nock');
-const { WEBHOOK_EVENT_TYPE_GROUPS } = require('@apify/consts');
+const { WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_TERMINAL_STATUSES } = require('@apify/consts');
 const _ = require('lodash');
 const { TASK_RUN_SAMPLE } = require('../../src/consts');
 const {
@@ -180,7 +180,7 @@ describe('task run finished trigger', () => {
                     },
                 });
             scope.get(`/v2/actor-tasks/${testTaskId}/runs`)
-                .query({ limit: 100, desc: true })
+                .query({ limit: 100, desc: true, status: ACTOR_JOB_TERMINAL_STATUSES.join(',') })
                 .reply(200, {
                     data: {
                         items: runs.map((run) => {


### PR DESCRIPTION
# Overview 
Apify’s core API recently extended the status parameter across multiple endpoints ([PR](https://github.com/apify/apify-core/pull/22240)).

This PR updates our implementation to leverage that enhancement. Retrieving runs with multiple statuses now uses the API’s built-in functionality, rather than fetching all runs and filtering them manually.