### PR TITLE
hotfix: Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,21 +60,18 @@ jobs:
 
             - name: Update CHANGELOG.md
               run: |
-                  if [ -n "${{ github.event.release.body }}" ]; then
+                  if [ -n "$RELEASE_BODY" ]; then
                     # Get current date in YYYY-MM-DD format
                     CURRENT_DATE=$(date '+%Y-%m-%d')
 
-                    # Compose the entire changelog entry with proper format
-                    CHANGELOG_ENTRY="## ${{ env.VERSION }} / ${CURRENT_DATE}"
-                    CHANGELOG_ENTRY="${CHANGELOG_ENTRY}"$'\n'"${{ github.event.release.body }}"
-                    CHANGELOG_ENTRY="${CHANGELOG_ENTRY}"$'\n'
-
                     # Check if CHANGELOG.md already contains this version
-                    if [ -f CHANGELOG.md ] && grep -q "^## ${{ env.VERSION }} /" CHANGELOG.md; then
+                    if [ -f CHANGELOG.md ] && grep -q "## ${{ env.VERSION }} /" CHANGELOG.md; then
                       echo "CHANGELOG.md already contains version ${{ env.VERSION }}. Skipping update."
                     else
                       # Create temporary file with new entry
-                      echo "${CHANGELOG_ENTRY}" > temp_changelog.md
+                      echo "## ${{ env.VERSION }} / ${CURRENT_DATE}" > temp_changelog.md
+                      echo "$RELEASE_BODY" >> temp_changelog.md
+                      echo "" >> temp_changelog.md
 
                       # Append existing CHANGELOG.md content if it exists
                       if [ -f CHANGELOG.md ]; then
@@ -86,6 +83,8 @@ jobs:
                       echo "CHANGELOG.md updated with release notes for version ${{ env.VERSION }}."
                     fi
                   fi
+              env:
+                  RELEASE_BODY: ${{ github.event.release.body }}
 
             - name: Commit changes
               run: |


### PR DESCRIPTION
Hotfix for failed publish workflow.

The failure happened when triggered by this [release](https://github.com/apify/apify-zapier-integration/releases/tag/v4.4.0).

The workflow failed because of the inclusion of double quotes (`"`) in the release description which caused the bash script which updates the changelog to quite early. I have made the solution more robust and the quotes are handled properly.

---

Here is a test run of this workflow on my test repo: https://github.com/matyascimbulka/zapier-test-app/actions/runs/16940272807 for this release: https://github.com/matyascimbulka/zapier-test-app/releases/tag/v0.1.17