### PR TITLE
fix: default status string fix

### DIFF
--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -15,7 +15,7 @@ const getLastActorRun = async (z, bundle) => {
     try {
         lastActorRunResponse = await wrapRequestWithRetries(z.request, {
             url: `${APIFY_API_ENDPOINTS.actors}/${actorId}/runs/last`,
-            params: status ? { status } : {},
+            params: status ? { status: status.toUpperCase() } : {},
         });
     } catch (err) {
         if (err.message.includes('not found')) return [];


### PR DESCRIPTION
The problem is that even though the status input is a dropdown, initially Zapier displays it as a string input field. When used like this, the key you enter in the field is not pointing to a value like: `'Succeeded': 'SUCCEEDED'`. Simple fix was to make status always capital in the background.

<img width="780" height="78" alt="Screenshot 2025-08-19 at 13 40 19" src="https://github.com/user-attachments/assets/49bb6d4e-6389-4db1-81be-5fc2ff8538ba" />
