### PR TITLE
fix: dropdown UI fix

### DIFF
--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -1,3 +1,4 @@
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const {
     ACTOR_RUN_SAMPLE,
     ACTOR_RUN_OUTPUT_FIELDS,
@@ -7,7 +8,6 @@ const {
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 const { getActorDatasetOutputFields } = require('../output_fields');
-const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 
 const getLastActorRun = async (z, bundle) => {
     const { actorId, status } = bundle.inputData;

--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -7,6 +7,7 @@ const {
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 const { getActorDatasetOutputFields } = require('../output_fields');
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 
 const getLastActorRun = async (z, bundle) => {
     const { actorId, status } = bundle.inputData;
@@ -15,9 +16,7 @@ const getLastActorRun = async (z, bundle) => {
     try {
         lastActorRunResponse = await wrapRequestWithRetries(z.request, {
             url: `${APIFY_API_ENDPOINTS.actors}/${actorId}/runs/last`,
-            // Using upper case to fix Zapier UI default value issues
-            // More info on Ticket: #98
-            params: status ? { status: status.toUpperCase() } : {},
+            params: status ? { status } : {},
         });
     } catch (err) {
         if (err.message.includes('not found')) return [];
@@ -51,7 +50,7 @@ module.exports = {
                 key: 'status',
                 required: false,
                 // Zapier selection dropdown expects individual options to be passed in { value: label } form
-                default: ACTOR_RUN_STATUSES.SUCCEEDED,
+                default: ACTOR_JOB_STATUSES.SUCCEEDED,
                 choices: ACTOR_RUN_STATUSES,
             },
         ],

--- a/src/searches/task_last_run.js
+++ b/src/searches/task_last_run.js
@@ -7,6 +7,7 @@ const {
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 const { getTaskDatasetOutputFields } = require('../output_fields');
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 
 const getLastTaskRun = async (z, bundle) => {
     const { taskId, status } = bundle.inputData;
@@ -15,9 +16,7 @@ const getLastTaskRun = async (z, bundle) => {
     try {
         lastTaskRunResponse = await wrapRequestWithRetries(z.request, {
             url: `${APIFY_API_ENDPOINTS.tasks}/${taskId}/runs/last`,
-            // Using upper case to fix Zapier UI default value issues
-            // More info on Ticket: #98
-            params: status ? { status: status.toUpperCase() } : {},
+            params: status ? { status } : {},
         });
     } catch (err) {
         if (err.message.includes('not found')) return [];
@@ -53,7 +52,7 @@ module.exports = {
                 key: 'status',
                 required: false,
                 // Zapier selection dropdown expects individual options to be passed in { value: label } form
-                default: ACTOR_RUN_STATUSES.SUCCEEDED,
+                default: ACTOR_JOB_STATUSES.SUCCEEDED,
                 choices: ACTOR_RUN_STATUSES,
             },
         ],

--- a/src/searches/task_last_run.js
+++ b/src/searches/task_last_run.js
@@ -1,3 +1,4 @@
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const {
     TASK_RUN_SAMPLE,
     TASK_RUN_OUTPUT_FIELDS,
@@ -7,7 +8,6 @@ const {
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
 const { getTaskDatasetOutputFields } = require('../output_fields');
-const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 
 const getLastTaskRun = async (z, bundle) => {
     const { taskId, status } = bundle.inputData;


### PR DESCRIPTION
Zapier run status dropdown was rendering as text. I asked this to Zapier support team: https://mail.google.com/mail/u/0/#inbox/QgrcJHrnvrJKMqgBXBbRvtDqRBlfHqdcvPl

Removed the old workaround solution of capitalizing letters.