### PR TITLE
feat: add fields and omit options to Fetch Dataset Items

### DIFF
--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -28,13 +28,19 @@ const findDatasetByNameOrId = async (z, datasetIdOrName) => {
 };
 
 const getItems = async (z, bundle) => {
-    const { datasetIdOrName, limit, offset } = bundle.inputData;
+    const { datasetIdOrName, limit, offset, fields, omit } = bundle.inputData;
     const dataset = await findDatasetByNameOrId(z, datasetIdOrName);
 
     // NOTE: Because testing user had _id instead of id in data and we run integration tests under this user.
     dataset.id = dataset.id || dataset._id;
 
-    const datasetItems = await getDatasetItems(z, dataset.id, bundle.authData.access_token, { limit, offset }, dataset.actId);
+    const trimFields = (value) => value.split(',').map((f) => f.trim()).join(',');
+
+    const params = { limit, offset };
+    if (fields && fields.length) params.fields = trimFields(fields);
+    if (omit && omit.length) params.omit = trimFields(omit);
+
+    const datasetItems = await getDatasetItems(z, dataset.id, bundle.authData.access_token, params, dataset.actId);
 
     // Pick some fields to Zapier UI, other fields are useless for Zapier users.
     const cleanDataset = _.pick(dataset, DATASET_PUBLISH_FIELDS);
@@ -61,6 +67,10 @@ module.exports = {
     },
 
     operation: {
+        inputFieldGroups: [
+            { key: 'basic', label: 'Basic Options', emphasize: true },
+            { key: 'advanced', label: 'Advanced Options', emphasize: false },
+        ],
         inputFields: [
             {
                 label: 'Dataset',
@@ -69,6 +79,7 @@ module.exports = {
                     + 'The usual way is to use default dataset ID from the task or the Actor run trigger.',
                 key: 'datasetIdOrName',
                 required: true,
+                group: 'basic',
             },
             {
                 label: 'Limit',
@@ -76,6 +87,7 @@ module.exports = {
                 key: 'limit',
                 required: false,
                 type: 'integer',
+                group: 'basic',
             },
             {
                 label: 'Offset',
@@ -83,6 +95,27 @@ module.exports = {
                 key: 'offset',
                 required: false,
                 type: 'integer',
+                group: 'basic',
+            },
+            {
+                label: 'Fields',
+                helpText: 'Only return these fields in each item, as a comma-separated list (e.g. `title,url,price`). '
+                    + 'All other fields will be dropped from the result. Leave empty to return all fields. '
+                    + 'Takes priority over **Omit** when both are set.',
+                key: 'fields',
+                required: false,
+                type: 'string',
+                group: 'advanced',
+            },
+            {
+                label: 'Omit',
+                helpText: 'Remove these fields from each item, as a comma-separated list (e.g. `_id,createdAt`). '
+                    + 'All other fields will be kept. Leave empty to return all fields. '
+                    + 'Ignored for any field that is also listed in **Fields**.',
+                key: 'omit',
+                required: false,
+                type: 'string',
+                group: 'advanced',
             },
         ],
 

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -31,6 +31,64 @@ describe('fetch dataset items', () => {
         }
     });
 
+    it('passes fields param to API when fields option is set', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const fields = 'name, url';
+        const filteredItems = [{ name: 'test', url: 'https://example.com' }];
+
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: {
+                datasetIdOrName: testDatasetId,
+                fields,
+            },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, { data: getMockDataset({ id: testDatasetId }) });
+        scope.get(`/v2/datasets/${testDatasetId}/items`)
+            .query({ limit: null, offset: null, clean: true, fields: 'name,url' })
+            .reply(200, filteredItems);
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, mockDatasetPublicUrl(testDatasetId));
+
+        const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
+
+        expect(testResult[0].items).to.eql(filteredItems);
+        scope.done();
+    });
+
+    it('passes omit param to API when omit option is set', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const omit = '_id, _debugInfo';
+        const filteredItems = [{ name: 'test', url: 'https://example.com' }];
+
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: {
+                datasetIdOrName: testDatasetId,
+                omit,
+            },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, { data: getMockDataset({ id: testDatasetId }) });
+        scope.get(`/v2/datasets/${testDatasetId}/items`)
+            .query({ limit: null, offset: null, clean: true, omit: '_id,_debugInfo' })
+            .reply(200, filteredItems);
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, mockDatasetPublicUrl(testDatasetId));
+
+        const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
+
+        expect(testResult[0].items).to.eql(filteredItems);
+        scope.done();
+    });
+
     it('work', async () => {
         const randomItems = [];
         for (let i = 0; i < 1000; i++) {


### PR DESCRIPTION
## Summary

- Adds **Fields** input — a comma-separated list of fields to include in each result item (e.g. `url, image, offers`), mapped to the `fields` query param of the [Apify Dataset Items API](https://docs.apify.com/api/v2/dataset-items-get)
- Adds **Omit** input — a comma-separated list of fields to exclude from each result item, mapped to the `omit` query param
- Both fields are placed in a collapsed **Advanced Options** group in the Zapier UI (using `inputFieldGroups` with `emphasize: false`)
- Spaces around commas are trimmed before sending to the API, so `url, image, offers` becomes `url,image,offers`

## Test plan

- [x] Unit test: `fields` with spaces (`'name, url'`) is trimmed and sent as `fields=name,url`
- [x] Unit test: `omit` with spaces (`'_id, _debugInfo'`) is trimmed and sent as `omit=_id,_debugInfo`
- [x] Existing `work` test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)