### PR TITLE
fix: replace default values with placeholders 

### DIFF
--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -368,13 +368,15 @@ const convertPropertyToInputFields = (z, propertyKey, definition, required) => {
             // We will use stringList type instead for simplicity. We will covert them into spec. format before run.
                 field.type = 'string';
                 field.list = true;
-                // NOTE: List can have just one default value, so pick just first one.
+                // NOTE: Use placeholder (not default) for prefill values. Setting default on a list field causes Zapier
+                // to pre-populate a non-removable first item, which duplicates entries and prevents users from
+                // controlling which values are sent.
                 if (parsedPrefillValue && Array.isArray(parsedPrefillValue) && parsedPrefillValue[0]) {
                     const firstItem = parsedPrefillValue[0];
-                    if (typeof firstItem === 'string') field.default = firstItem;
-                    else if (typeof firstItem === 'object') field.default = firstItem.url || firstItem.purl || firstItem.glob;
-                    else field.default = firstItem; // NOTE: We do not know what it is, let's print it as it is, but it should not happen.
-                    field.placeholder = undefined;
+                    if (typeof firstItem === 'string') field.placeholder = firstItem;
+                    else if (typeof firstItem === 'object') field.placeholder = firstItem.url || firstItem.purl || firstItem.glob;
+                    else field.placeholder = firstItem; // NOTE: We do not know what it is, let's print it as it is, but it should not happen.
+                    field.default = undefined;
                 } else if (parsedDefaultValue && Array.isArray(parsedDefaultValue) && parsedDefaultValue[0]) {
                     const firstItem = parsedDefaultValue[0];
                     if (typeof firstItem === 'string') field.placeholder = firstItem;

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -488,13 +488,13 @@ describe('create actor run', () => {
             const startUrlsFieldSchema = properties.startUrls;
             expect(startUrlsField.label).to.be.equal(startUrlsFieldSchema.title);
             expect(startUrlsField.helpText).to.be.equal(startUrlsFieldSchema.description);
-            expect(startUrlsField.default).to.be.deep.equal(startUrlsFieldSchema.prefill.map(({ url }) => url)[0]);
+            expect(startUrlsField.placeholder).to.be.deep.equal(startUrlsFieldSchema.prefill.map(({ url }) => url)[0]);
 
             const pseudoUrlsField = fields.find(({ key }) => key === 'input-pseudoUrls');
             const pseudoUrlsFieldSchema = properties.pseudoUrls;
             expect(pseudoUrlsField.label).to.be.equal(pseudoUrlsFieldSchema.title);
             expect(pseudoUrlsField.helpText).to.be.equal(pseudoUrlsFieldSchema.description);
-            expect(pseudoUrlsField.default).to.be.deep.equal(pseudoUrlsFieldSchema.prefill.map(({ purl }) => purl)[0]);
+            expect(pseudoUrlsField.placeholder).to.be.deep.equal(pseudoUrlsFieldSchema.prefill.map(({ purl }) => purl)[0]);
 
             const proxyConfigurationField = fields.find(({ key }) => key === 'input-proxyConfiguration');
             const proxyConfigurationFieldSchema = properties.proxyConfiguration;


### PR DESCRIPTION
You can test in on platform version - 4.5.7

This should fix the default value that could not be removed from the list.
See issue for more details.

closes #119