### PR TITLE
fix: trigger download items 30s timeout

### DIFF
--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -2,8 +2,9 @@ const _ = require('lodash');
 const { BUILD_TAG_LATEST, ACTOR_JOB_TERMINAL_STATUSES } = require('@apify/consts');
 const { ApifyClient } = require('apify-client');
 const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRAWLER_ID,
-    OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, ALLOWED_MEMORY_MBYTES_LIST,
-    DEFAULT_ACTOR_MEMORY_MBYTES, ACTOR_RUN_TERMINAL_STATUSES, ACTOR_RUN_TERMINAL_EVENT_TYPES,
+    OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, DATASET_ITEMS_INLINE_MAX_COUNT,
+    ALLOWED_MEMORY_MBYTES_LIST, DEFAULT_ACTOR_MEMORY_MBYTES, ACTOR_RUN_TERMINAL_STATUSES,
+    ACTOR_RUN_TERMINAL_EVENT_TYPES,
 } = require('./consts');
 const { wrapRequestWithRetries } = require('./request_helpers');
 
@@ -54,6 +55,19 @@ const getDatasetItems = async (z, datasetId, token, params = {}, actorId, runFro
         cleanParamName = 'simplified';
     }
     params[cleanParamName] = true;
+
+    if (runFromTrigger) {
+        const datasetInfoResponse = await wrapRequestWithRetries(z.request, {
+            url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}`,
+        });
+        const { itemCount } = datasetInfoResponse.data;
+        if (itemCount > DATASET_ITEMS_INLINE_MAX_COUNT) {
+            throw new Error(
+                `Dataset has ${itemCount} items and is too large to fetch inline (limit: ${DATASET_ITEMS_INLINE_MAX_COUNT}). `
+                + 'Use the dataset file URL fields to download your data instead.',
+            );
+        }
+    }
 
     const itemsResponse = await wrapRequestWithRetries(z.request, {
         url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}/items`,

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const { BUILD_TAG_LATEST, ACTOR_JOB_TERMINAL_STATUSES } = require('@apify/consts');
 const { ApifyClient } = require('apify-client');
 const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRAWLER_ID,
-    OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, DATASET_ITEMS_INLINE_MAX_COUNT,
+    OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, DATASET_ITEMS_INLINE_MAX_BYTES,
     ALLOWED_MEMORY_MBYTES_LIST, DEFAULT_ACTOR_MEMORY_MBYTES, ACTOR_RUN_TERMINAL_STATUSES,
     ACTOR_RUN_TERMINAL_EVENT_TYPES,
 } = require('./consts');
@@ -41,6 +41,32 @@ const createDatasetUrls = async (datasetId, token, cleanParamName) => {
 };
 
 /**
+ * Estimates whether a dataset is too large to download inline.
+ * Returns null if the size is acceptable, or { estimatedMB, downloadItems } if the limit is exceeded.
+ */
+const isTooLargeToDownload = async (z, datasetId, limit = undefined) => {
+    const datasetInfoResponse = await wrapRequestWithRetries(z.request, {
+        url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}`,
+    });
+
+    const { itemCount, cleanItemCount, stats } = datasetInfoResponse.data;
+    const storageBytes = stats?.storageBytes;
+    const totalItems = itemCount || 0;
+
+    if (!storageBytes || totalItems === 0) return null;
+
+    const downloadItems = Math.min(limit || FETCH_DATASET_ITEMS_ITEMS_LIMIT, cleanItemCount ?? totalItems);
+    const estimatedBytes = Math.round((storageBytes * downloadItems) / totalItems);
+
+    if (estimatedBytes <= DATASET_ITEMS_INLINE_MAX_BYTES) return null;
+
+    return {
+        estimatedMB: (estimatedBytes / (1024 * 1024)).toFixed(1),
+        downloadItems,
+    };
+};
+
+/**
  * Get items from dataset and urls to file attachments. If there are more than limit items,
  * it will attach item with info about reaching limit.
  */
@@ -56,15 +82,15 @@ const getDatasetItems = async (z, datasetId, token, params = {}, actorId, runFro
     }
     params[cleanParamName] = true;
 
+    datasetId = 'v1mTcgT587jgswg6j';
+
     if (runFromTrigger) {
-        const datasetInfoResponse = await wrapRequestWithRetries(z.request, {
-            url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}`,
-        });
-        const { itemCount } = datasetInfoResponse.data;
-        if (itemCount > DATASET_ITEMS_INLINE_MAX_COUNT) {
+        const tooLarge = await isTooLargeToDownload(z, datasetId, params?.limit);
+        if (tooLarge) {
+            const limitMB = DATASET_ITEMS_INLINE_MAX_BYTES / (1024 * 1024);
             throw new Error(
-                `Dataset has ${itemCount} items and is too large to fetch inline (limit: ${DATASET_ITEMS_INLINE_MAX_COUNT}). `
-                + 'Use the dataset file URL fields to download your data instead.',
+                `Dataset items are too large to download inline (~${tooLarge.estimatedMB} MB estimated for ${tooLarge.downloadItems} items,
+                limit: ${limitMB} MB).`,
             );
         }
     }

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -41,27 +41,25 @@ const createDatasetUrls = async (datasetId, token, cleanParamName) => {
 };
 
 /**
- * Estimates whether a dataset is too large to download inline.
- * Returns null if the size is acceptable, or { estimatedMB, downloadItems } if the limit is exceeded.
+ * Checks whether a dataset is too large to download inline by fetching a single item
+ * and checking if that item alone would push the full download over the limit.
+ * Returns null if the size is acceptable, or { singleItemMB, downloadItems } if the limit is exceeded.
  */
-const isTooLargeToDownload = async (z, datasetId, limit = undefined) => {
-    const datasetInfoResponse = await wrapRequestWithRetries(z.request, {
-        url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}`,
+const isTooLargeToDownload = async (z, datasetId, params) => {
+    const sampleResponse = await wrapRequestWithRetries(z.request, {
+        url: `${APIFY_API_ENDPOINTS.datasets}/${datasetId}/items`,
+        params: { ...params, limit: 1 },
     });
 
-    const { itemCount, cleanItemCount, stats } = datasetInfoResponse.data;
-    const storageBytes = stats?.storageBytes;
-    const totalItems = itemCount || 0;
+    const singleItemBytes = Buffer.byteLength(sampleResponse.content);
+    if (singleItemBytes <= 2) return null; // empty array "[]" — nothing to download
 
-    if (!storageBytes || totalItems === 0) return null;
+    const downloadItems = params.limit || FETCH_DATASET_ITEMS_ITEMS_LIMIT;
 
-    const downloadItems = Math.min(limit || FETCH_DATASET_ITEMS_ITEMS_LIMIT, cleanItemCount ?? totalItems);
-    const estimatedBytes = Math.round((storageBytes * downloadItems) / totalItems);
-
-    if (estimatedBytes <= DATASET_ITEMS_INLINE_MAX_BYTES) return null;
+    if (singleItemBytes * downloadItems <= DATASET_ITEMS_INLINE_MAX_BYTES) return null;
 
     return {
-        estimatedMB: (estimatedBytes / (1024 * 1024)).toFixed(1),
+        singleItemMB: (singleItemBytes / (1024 * 1024)).toFixed(1),
         downloadItems,
     };
 };
@@ -82,16 +80,21 @@ const getDatasetItems = async (z, datasetId, token, params = {}, actorId, runFro
     }
     params[cleanParamName] = true;
 
-    datasetId = 'v1mTcgT587jgswg6j';
-
     if (runFromTrigger) {
-        const tooLarge = await isTooLargeToDownload(z, datasetId, params?.limit);
+        const tooLarge = await isTooLargeToDownload(z, datasetId, params);
         if (tooLarge) {
             const limitMB = DATASET_ITEMS_INLINE_MAX_BYTES / (1024 * 1024);
-            throw new Error(
-                `Dataset items are too large to download inline (~${tooLarge.estimatedMB} MB estimated for ${tooLarge.downloadItems} items,
-                limit: ${limitMB} MB).`,
-            );
+            const limitWarning = `Dataset items are too large to download inline
+                (first item is ~${tooLarge.singleItemMB} MB, limit is ${limitMB} MB for ${tooLarge.downloadItems} items total).
+                Use field selection options to limit which fields are downloaded,
+                or use the dataset file URL fields to download your data instead.`;
+
+            return {
+                items: [
+                    { warning: limitWarning },
+                ],
+                itemsFileUrls: await createDatasetUrls(datasetId, token, cleanParamName),
+            };
         }
     }
 

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -5,6 +5,7 @@ const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRA
     OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, DATASET_ITEMS_INLINE_MAX_BYTES,
     ALLOWED_MEMORY_MBYTES_LIST, DEFAULT_ACTOR_MEMORY_MBYTES, ACTOR_RUN_TERMINAL_STATUSES,
     ACTOR_RUN_TERMINAL_EVENT_TYPES,
+    DATASET_MAX_SIZE_MARGIN,
 } = require('./consts');
 const { wrapRequestWithRetries } = require('./request_helpers');
 
@@ -56,7 +57,7 @@ const isTooLargeToDownload = async (z, datasetId, params) => {
 
     const downloadItems = params.limit || FETCH_DATASET_ITEMS_ITEMS_LIMIT;
 
-    if (singleItemBytes * downloadItems <= DATASET_ITEMS_INLINE_MAX_BYTES) return null;
+    if (singleItemBytes * downloadItems * DATASET_MAX_SIZE_MARGIN <= DATASET_ITEMS_INLINE_MAX_BYTES) return null;
 
     return {
         singleItemMB: (singleItemBytes / (1024 * 1024)).toFixed(1),

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -84,10 +84,10 @@ const getDatasetItems = async (z, datasetId, token, params = {}, actorId, runFro
         const tooLarge = await isTooLargeToDownload(z, datasetId, params);
         if (tooLarge) {
             const limitMB = DATASET_ITEMS_INLINE_MAX_BYTES / (1024 * 1024);
-            const limitWarning = `Dataset items are too large to download inline
-                (first item is ~${tooLarge.singleItemMB} MB, limit is ${limitMB} MB for ${tooLarge.downloadItems} items total).
-                Use field selection options to limit which fields are downloaded,
-                or use the dataset file URL fields to download your data instead.`;
+            const limitWarning = 'Dataset items are too large to download inline '
+                + `(first item is ~${tooLarge.singleItemMB} MB, limit is ${limitMB} MB for ${tooLarge.downloadItems} items total). `
+                + 'Use field selection options to limit which fields are downloaded, '
+                + 'or use the dataset file URL fields to download your data instead.';
 
             return {
                 items: [

--- a/src/consts.js
+++ b/src/consts.js
@@ -285,6 +285,7 @@ const DATASET_PUBLISH_FIELDS = ['id', 'name', 'createdAt', 'modifiedAt', 'itemCo
 const FETCH_DATASET_ITEMS_ITEMS_LIMIT = 100;
 // Maximum estimated response size for inline dataset item fetching in triggers. Larger datasets must be downloaded via file URLs.
 const DATASET_ITEMS_INLINE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const DATASET_MAX_SIZE_MARGIN = 1.2; // 20% safety margin for the dataset size
 
 // List of allowed memory for actor run 128, 256, 512 ..
 const ALLOWED_MEMORY_MBYTES_LIST = Array.from(
@@ -340,6 +341,7 @@ module.exports = {
     DATASET_PUBLISH_FIELDS,
     FETCH_DATASET_ITEMS_ITEMS_LIMIT,
     DATASET_ITEMS_INLINE_MAX_BYTES,
+    DATASET_MAX_SIZE_MARGIN,
     ALLOWED_MEMORY_MBYTES_LIST,
     DEFAULT_RUN_WAIT_TIME_OUT_SECONDS,
     DEFAULT_ACTOR_MEMORY_MBYTES,

--- a/src/consts.js
+++ b/src/consts.js
@@ -283,8 +283,8 @@ const OMIT_ACTOR_RUN_FIELDS = ['meta', 'stats', 'options', 'userId', 'output'];
 const DATASET_PUBLISH_FIELDS = ['id', 'name', 'createdAt', 'modifiedAt', 'itemCount', 'cleanItemCount', 'actId', 'actRunId'];
 
 const FETCH_DATASET_ITEMS_ITEMS_LIMIT = 100;
-// Maximum dataset item count for inline fetching in triggers/actions. Larger datasets must be downloaded via file URLs.
-const DATASET_ITEMS_INLINE_MAX_COUNT = 1000;
+// Maximum estimated response size for inline dataset item fetching in triggers. Larger datasets must be downloaded via file URLs.
+const DATASET_ITEMS_INLINE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 
 // List of allowed memory for actor run 128, 256, 512 ..
 const ALLOWED_MEMORY_MBYTES_LIST = Array.from(
@@ -339,7 +339,7 @@ module.exports = {
     OMIT_ACTOR_RUN_FIELDS,
     DATASET_PUBLISH_FIELDS,
     FETCH_DATASET_ITEMS_ITEMS_LIMIT,
-    DATASET_ITEMS_INLINE_MAX_COUNT,
+    DATASET_ITEMS_INLINE_MAX_BYTES,
     ALLOWED_MEMORY_MBYTES_LIST,
     DEFAULT_RUN_WAIT_TIME_OUT_SECONDS,
     DEFAULT_ACTOR_MEMORY_MBYTES,

--- a/src/consts.js
+++ b/src/consts.js
@@ -283,6 +283,8 @@ const OMIT_ACTOR_RUN_FIELDS = ['meta', 'stats', 'options', 'userId', 'output'];
 const DATASET_PUBLISH_FIELDS = ['id', 'name', 'createdAt', 'modifiedAt', 'itemCount', 'cleanItemCount', 'actId', 'actRunId'];
 
 const FETCH_DATASET_ITEMS_ITEMS_LIMIT = 100;
+// Maximum dataset item count for inline fetching in triggers/actions. Larger datasets must be downloaded via file URLs.
+const DATASET_ITEMS_INLINE_MAX_COUNT = 1000;
 
 // List of allowed memory for actor run 128, 256, 512 ..
 const ALLOWED_MEMORY_MBYTES_LIST = Array.from(
@@ -337,6 +339,7 @@ module.exports = {
     OMIT_ACTOR_RUN_FIELDS,
     DATASET_PUBLISH_FIELDS,
     FETCH_DATASET_ITEMS_ITEMS_LIMIT,
+    DATASET_ITEMS_INLINE_MAX_COUNT,
     ALLOWED_MEMORY_MBYTES_LIST,
     DEFAULT_RUN_WAIT_TIME_OUT_SECONDS,
     DEFAULT_ACTOR_MEMORY_MBYTES,

--- a/test/creates/actor_run.js
+++ b/test/creates/actor_run.js
@@ -625,6 +625,9 @@ describe('create actor run', () => {
         scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
             .reply(200, { foo: 'bar' });
         scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+            .query({ limit: 1, clean: true })
+            .reply(200, [{ foo: 'bar' }]);
+        scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
             .query({ limit: 100, clean: true })
             .reply(200, [{ foo: 'bar' }]);
         scope.get(`/v2/datasets/${mockRun.defaultDatasetId}`)
@@ -672,6 +675,9 @@ describe('create actor run', () => {
                 .reply(200, { data: run });
             scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, { foo: 'bar' });
+            scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
             scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ foo: 'bar' }]);
@@ -737,6 +743,9 @@ describe('create actor run', () => {
                     contentType: 'text/plain; charset=utf-8',
                 });
             scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+            scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ foo: 'bar' }]);
             scope.get(`/v2/datasets/${run.defaultDatasetId}`)
@@ -791,6 +800,9 @@ describe('create actor run', () => {
                 .reply(200, { data: mockActorRun });
             scope.get(`/v2/key-value-stores/${mockActorRun.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, {});
+            scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, []);
             scope.get(`/v2/datasets/${ACTOR_RUN_SAMPLE.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, []);

--- a/test/creates/scrape_single_url.js
+++ b/test/creates/scrape_single_url.js
@@ -7,7 +7,6 @@ const nock = require('nock');
 const { TEST_USER_TOKEN, apifyClient, getMockRun, mockDatasetPublicUrl } = require('../helpers');
 const App = require('../../index');
 const { SCRAPE_SINGLE_URL_RUN_SAMPLE } = require('../../src/consts');
-const { waitForRunToFinish } = require('../../src/request_helpers');
 
 const appTester = zapier.createAppTester(App);
 
@@ -73,6 +72,9 @@ describe('scrape single URL', () => {
                 memory: 1024,
             })
             .reply(200, { data: mockRun });
+        scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+            .query({ limit: 1, clean: true })
+            .reply(200, [mockDatasetItem]);
         scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
             .query({ limit: 1, clean: true })
             .reply(200, [mockDatasetItem]);
@@ -172,7 +174,10 @@ describe('scrape single URL', () => {
             scope.get(`/v2/datasets/${SCRAPE_SINGLE_URL_RUN_SAMPLE.defaultDatasetId}/items`)
                 .query({ limit: 1, clean: true })
                 .reply(200, []);
-            
+            scope.get(`/v2/datasets/${SCRAPE_SINGLE_URL_RUN_SAMPLE.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, []);
+
             scope.get(`/v2/actor-runs/${SCRAPE_SINGLE_URL_RUN_SAMPLE.id}`)
                 .query(true)
                 .reply(200, { data: SCRAPE_SINGLE_URL_RUN_SAMPLE });

--- a/test/creates/task_run.js
+++ b/test/creates/task_run.js
@@ -3,7 +3,14 @@ const zapier = require('zapier-platform-core');
 const { expect } = require('chai');
 const _ = require('lodash');
 const nock = require('nock');
-const { TEST_USER_TOKEN, apifyClient, createWebScraperTask, createLegacyCrawlerTask, randomString, getMockRun, mockDatasetPublicUrl } = require('../helpers');
+const { TEST_USER_TOKEN,
+    apifyClient,
+    createWebScraperTask,
+    createLegacyCrawlerTask,
+    randomString,
+    getMockRun,
+    mockDatasetPublicUrl,
+} = require('../helpers');
 const { TASK_RUN_SAMPLE, KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
@@ -72,6 +79,9 @@ describe('create task run', () => {
             scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, KEY_VALUE_STORE_SAMPLE);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ url: urlToScrape }]);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ url: urlToScrape }]);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}`)
@@ -113,6 +123,9 @@ describe('create task run', () => {
             scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, { ...KEY_VALUE_STORE_SAMPLE, error: 'No output' });
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, []);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, []);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}`)
@@ -152,6 +165,9 @@ describe('create task run', () => {
             scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, KEY_VALUE_STORE_SAMPLE);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ url: 'http://example.com' }]);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ url: 'http://example.com' }]);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}`)
@@ -188,6 +204,9 @@ describe('create task run', () => {
                 .reply(200, { data: { ...mockRun, status: 'SUCCEEDED' } });
             scope.get(`/v2/key-value-stores/${mockRun.defaultKeyValueStoreId}/records/OUTPUT`)
                 .reply(200, KEY_VALUE_STORE_SAMPLE);
+            scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ testedField: 'testValue' }]);
             scope.get(`/v2/datasets/${mockRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ testedField: 'testValue' }]);

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -334,6 +334,7 @@ const getMockDataset = (overrides) => {
         actId: null,
         actRunId: null,
         fields: [],
+        stats: { storageBytes: 1024 },
         consoleUrl: `https://console.apify.com/storage/datasets/${randomString()}`,
         ...overrides,
     };

--- a/test/searches/actor_last_run.js
+++ b/test/searches/actor_last_run.js
@@ -91,6 +91,9 @@ describe('search actor last run', () => {
                 .reply(200, KEY_VALUE_STORE_SAMPLE);
 
             scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ foo: 'bar' }]);
             scope.get(`/v2/datasets/${actorRun.defaultDatasetId}`)

--- a/test/searches/task_last_run.js
+++ b/test/searches/task_last_run.js
@@ -89,6 +89,9 @@ describe('search task last run', () => {
                 .reply(200, KEY_VALUE_STORE_SAMPLE);
 
             scope.get(`/v2/datasets/${taskRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+            scope.get(`/v2/datasets/${taskRun.defaultDatasetId}/items`)
                 .query({ limit: 100, clean: true })
                 .reply(200, [{ foo: 'bar' }]);
             scope.get(`/v2/datasets/${taskRun.defaultDatasetId}`)

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -6,7 +6,7 @@ const { WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_TERMINAL_STATUSES } = require('@api
 
 const _ = require('lodash');
 const { ActorListSortBy } = require('apify-client');
-const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse, mockDatasetPublicUrl } = require('../helpers');
+const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse, getMockDataset, mockDatasetPublicUrl } = require('../helpers');
 const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
@@ -183,10 +183,13 @@ describe('actor run finished trigger', () => {
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
                     .reply(200, { foo: 'bar' });
 
+                scope.get(`/v2/datasets/${run.defaultDatasetId}`)
+                    .reply(200, { data: getMockDataset({ id: run.defaultDatasetId }) });
+
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })
                     .reply(200, [{ foo: 'bar' }]);
-                
+
                 scope.get(`/v2/datasets/${run.defaultDatasetId}`)
                     .reply(200, mockDatasetPublicUrl(run.defaultDatasetId));
             });

--- a/test/triggers/actor_run_finished.js
+++ b/test/triggers/actor_run_finished.js
@@ -6,7 +6,14 @@ const { WEBHOOK_EVENT_TYPE_GROUPS, ACTOR_JOB_TERMINAL_STATUSES } = require('@api
 
 const _ = require('lodash');
 const { ActorListSortBy } = require('apify-client');
-const { createAndBuildActor, apifyClient, TEST_USER_TOKEN, randomString, getMockRun, getMockWebhookResponse, getMockDataset, mockDatasetPublicUrl } = require('../helpers');
+const { createAndBuildActor,
+    apifyClient,
+    TEST_USER_TOKEN,
+    randomString,
+    getMockRun,
+    getMockWebhookResponse,
+    mockDatasetPublicUrl,
+} = require('../helpers');
 const { ACTOR_RUN_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
@@ -183,8 +190,9 @@ describe('actor run finished trigger', () => {
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
                     .reply(200, { foo: 'bar' });
 
-                scope.get(`/v2/datasets/${run.defaultDatasetId}`)
-                    .reply(200, { data: getMockDataset({ id: run.defaultDatasetId }) });
+                scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                    .query({ limit: 1, clean: true })
+                    .reply(200, [{ foo: 'bar' }]);
 
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -8,7 +8,7 @@ const { TASK_RUN_SAMPLE } = require('../../src/consts');
 const {
     randomString, apifyClient, createWebScraperTask,
     TEST_USER_TOKEN, createLegacyCrawlerTask, getMockWebhookResponse, getMockTaskRun,
-    mockDatasetPublicUrl,
+    getMockDataset, mockDatasetPublicUrl,
 } = require('../helpers');
 
 const App = require('../../index');
@@ -198,9 +198,13 @@ describe('task run finished trigger', () => {
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
                     .reply(200, { foo: 'bar' });
 
+                scope.get(`/v2/datasets/${run.defaultDatasetId}`)
+                    .reply(200, { data: getMockDataset({ id: run.defaultDatasetId }) });
+
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })
                     .reply(200, [{ foo: 'bar' }]);
+
                 scope.get(`/v2/datasets/${run.defaultDatasetId}`)
                     .reply(200, mockDatasetPublicUrl(run.defaultDatasetId));
             });

--- a/test/triggers/task_run_finished.js
+++ b/test/triggers/task_run_finished.js
@@ -8,7 +8,7 @@ const { TASK_RUN_SAMPLE } = require('../../src/consts');
 const {
     randomString, apifyClient, createWebScraperTask,
     TEST_USER_TOKEN, createLegacyCrawlerTask, getMockWebhookResponse, getMockTaskRun,
-    getMockDataset, mockDatasetPublicUrl,
+    mockDatasetPublicUrl,
 } = require('../helpers');
 
 const App = require('../../index');
@@ -153,7 +153,7 @@ describe('task run finished trigger', () => {
             runs.push(getMockTaskRun());
             runs.push(getMockTaskRun());
 
-            runs.forEach((run) => { delete run.integrationTracking; })
+            runs.forEach((run) => { delete run.integrationTracking; });
         }
 
         const bundle = {
@@ -198,8 +198,9 @@ describe('task run finished trigger', () => {
                 scope.get(`/v2/key-value-stores/${run.defaultKeyValueStoreId}/records/OUTPUT`)
                     .reply(200, { foo: 'bar' });
 
-                scope.get(`/v2/datasets/${run.defaultDatasetId}`)
-                    .reply(200, { data: getMockDataset({ id: run.defaultDatasetId }) });
+                scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
+                    .query({ limit: 1, clean: true })
+                    .reply(200, [{ foo: 'bar' }]);
 
                 scope.get(`/v2/datasets/${run.defaultDatasetId}/items`)
                     .query({ limit: 100, clean: true })


### PR DESCRIPTION
                                                                            
Fixes dataset download timeouts that caused Zapier's 30s Lambda hard limit to kill the trigger silently.   
        
- The obvious easy solution is to use AbortController and/or timeout on the request if it reaches some treshhold like 25s. Sadly this doesn't work. 
                                                                     
- Why timeout/AbortController didn't work:                                    
  zapier-platform-core uses node-fetch v2, which only supports a TTFB timeout
  — not a total response time limit. Passing signal: AbortController.signal   
  has no effect in this version and doesn't kill the trigger
                                                                              
- Instead I've fallen back to estimating the dataset size and returning empty array for potentionally large datasets.
- The estimation just fetches the first item and multiplies it by number of preview datasets
   - It is not ideall and we should implement the omit/select options to the trigger, so we enable users to overcome this
   
- closes: https://github.com/orgs/apify/projects/54/views/4?filterQuery=is%3Aissue+assignee%3AJanHranicky&pane=issue&itemId=171857859&issue=apify%7Capify-zapier-integration%7C139  
                                                                                 