### PR TITLE
feat: zapier update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,16 +1881,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2248,9 +2248,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2830,10 +2830,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "apify-client": "2.19.0",
         "dayjs": "^1.11.21",
         "lodash": "^4.17.21",
-        "zapier-platform-core": "17.5.0"
+        "zapier-platform-core": "19.0.0"
       },
       "devDependencies": {
         "chai": "^4.5.0",
@@ -24,7 +24,7 @@
         "eslint-plugin-promise": "^7.3.0",
         "mocha": "^11.7.6",
         "nock": "^14.0.16",
-        "zapier-platform-schema": "16.5.0"
+        "zapier-platform-schema": "19.0.0"
       },
       "engines": {
         "node": "22",
@@ -55,6 +55,15 @@
       "dependencies": {
         "@apify/consts": "^2.53.3",
         "@apify/log": "^2.5.41"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@crawlee/types": {
@@ -1212,9 +1221,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2840,6 +2849,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-metaschema": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-metaschema/-/json-metaschema-1.3.0.tgz",
+      "integrity": "sha512-FMDPEZQzqIVOQZ3OxzWryI28W6IZ9QKLcHObO9bS+SJrwnV3xQD0QtnhtgSpIZd8Xuy0xBqeRA74vfTnpK4eVg==",
+      "license": "Public Domain"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2875,9 +2903,9 @@
       }
     },
     "node_modules/jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4347,6 +4375,12 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4870,23 +4904,24 @@
       }
     },
     "node_modules/zapier-platform-core": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-17.5.0.tgz",
-      "integrity": "sha512-/j1xCcQrYjhJBp/OeAFY8EKQNAYlON0ZOvqigYYIkMxI1RLwEnLieZ/p1IRpAfvCmaU8qEleK161hx4zt2MYMg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-19.0.0.tgz",
+      "integrity": "sha512-BWUq7BUQCM6oOITKgfhuStuWGGmWuYQsDi/vVspHts1AAaURSANczrO2eYaLxagMxcX0JovoOyAYm8tQltsCmA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@zapier/secret-scrubber": "^1.1.2",
         "content-disposition": "0.5.4",
-        "dotenv": "16.5.0",
+        "dotenv": "17.2.1",
         "fernet": "^0.3.3",
-        "form-data": "4.0.4",
-        "lodash": "4.17.21",
-        "mime-types": "2.1.35",
+        "form-data": "4.0.5",
+        "json-schema-to-ts": "3.1.1",
+        "lodash": "4.18.1",
+        "mime-types": "3.0.1",
         "node-abort-controller": "3.1.1",
         "node-fetch": "2.7.0",
         "oauth-sign": "0.9.0",
-        "semver": "7.7.1",
-        "zapier-platform-schema": "17.5.0"
+        "semver": "7.7.2",
+        "zapier-platform-schema": "19.0.0"
       },
       "engines": {
         "node": ">=16",
@@ -4894,28 +4929,41 @@
       },
       "optionalDependencies": {
         "@types/node": "^20.3.1"
+      },
+      "peerDependencies": {
+        "zapier-platform-legacy-scripting-runner": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zapier-platform-legacy-scripting-runner": {
+          "optional": true
+        }
       }
     },
-    "node_modules/zapier-platform-core/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+    "node_modules/zapier-platform-core/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/zapier-platform-core/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.6"
       }
     },
     "node_modules/zapier-platform-core/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4924,25 +4972,15 @@
         "node": ">=10"
       }
     },
-    "node_modules/zapier-platform-core/node_modules/zapier-platform-schema": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-17.5.0.tgz",
-      "integrity": "sha512-iqor7denJSaC88dfc/+rdyKfd/AdOF0f2QFqWCRshtaHx40KVValNKEm9BGwJDsiv76G3Tty5xFZUsSJWIgbOw==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "jsonschema": "1.2.2",
-        "lodash": "4.17.21"
-      }
-    },
     "node_modules/zapier-platform-schema": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.5.0.tgz",
-      "integrity": "sha512-EBVtU67ICz33k6zydQ3YNy72ydSbBsMVlBlTB7mQP8pByxdhmzITro/xdhj/zhb8npBo9v1OrX4qcCgmLbIkqw==",
-      "dev": true,
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-19.0.0.tgz",
+      "integrity": "sha512-mwy+1vaLBeFG5XGUbkmnwnk6EmY0yQeHKoY/wG24WtVuWacRKAmq9jbUZ1jVcor0zZBYyb7DD0GsYeSK+DR5dg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "jsonschema": "1.2.2",
-        "lodash": "4.17.21"
+        "json-metaschema": "1.3.0",
+        "jsonschema": "1.5.0",
+        "lodash": "4.18.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "apify-zapier-integration",
       "version": "4.5.8",
       "dependencies": {
-        "@apify/consts": "^2.40.0",
-        "@apify/utilities": "^2.15.4",
+        "@apify/consts": "^2.53.3",
+        "@apify/utilities": "^2.34.1",
         "apify-client": "2.15.0",
-        "dayjs": "^1.11.13",
+        "dayjs": "^1.11.21",
         "lodash": "^4.17.21",
         "zapier-platform-core": "17.5.0"
       },
@@ -21,40 +21,40 @@
         "eslint": "^8.42.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-promise": "^7.2.1",
-        "mocha": "^11.0.0",
-        "nock": "^14.0.4",
+        "eslint-plugin-promise": "^7.3.0",
+        "mocha": "^11.7.6",
+        "nock": "^14.0.16",
         "zapier-platform-schema": "16.5.0"
       },
       "engines": {
-        "node": "18",
+        "node": "22",
         "npm": ">=5.6.0"
       }
     },
     "node_modules/@apify/consts": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.47.0.tgz",
-      "integrity": "sha512-VFVrNn/S3bLPrS3v9x7Td5b8YtxPbrepuXLWu27n06T34qQeogysbnAWIBNnTQ59qRKlxrAeFR4ezI+fRXTMNQ==",
+      "version": "2.53.3",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.53.3.tgz",
+      "integrity": "sha512-X26SC8d6kLMSWzBcYldKgzKFJXGnTAka/bRmvL+iYHJEabFzVYupj64kGhar6QTPeGKNt6WR/hNE+dToNqHZQA==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/log": {
-      "version": "2.5.26",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.26.tgz",
-      "integrity": "sha512-o/Ciki7UwaXwdJ+tvTg7WG8Q3C+hZXYUpo2FrTG7Upr1PQW45PGfwLDuJxteIBsEXjIHtWitlLi4AZwG7mtRMQ==",
+      "version": "2.5.41",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.41.tgz",
+      "integrity": "sha512-c826B4jhfF6CBOgyGyZyiT4GrhPaFWrZegFbY6bk/ffQc5BCPqAOT315qEEpFE4d6hP0d86tdcsiRknxkEFO0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.47.0",
+        "@apify/consts": "^2.53.3",
         "ansi-colors": "^4.1.1"
       }
     },
     "node_modules/@apify/utilities": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.23.1.tgz",
-      "integrity": "sha512-6QihDFE277upQ+6WIBDVk3c1xZntRgd6JPNQ9SDtOV6hxSQZkrQZijhLrIt+/Mj5o5bp5RyQdnFzY0aspvMcrA==",
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.34.1.tgz",
+      "integrity": "sha512-9jHBMQEcJS/NTQg2joYOH8QdvEZLPNteKwV3dCpSQcQs0dsK8TgrAbc/ZzJWlK4/HSJK/RKQ1QbD1Ntoh9FwUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.47.0",
-        "@apify/log": "^2.5.26"
+        "@apify/consts": "^2.53.3",
+        "@apify/log": "^2.5.41"
       }
     },
     "node_modules/@crawlee/types": {
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.39.8",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.8.tgz",
-      "integrity": "sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
-      "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1619,7 +1619,7 @@
         "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3150,13 +3150,13 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "14.0.10",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.10.tgz",
-      "integrity": "sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==",
+      "version": "14.0.16",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.16.tgz",
+      "integrity": "sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.39.5",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apify/consts": "^2.53.3",
         "@apify/utilities": "^2.34.1",
-        "apify-client": "2.15.0",
+        "apify-client": "2.19.0",
         "dayjs": "^1.11.21",
         "lodash": "^4.17.21",
         "zapier-platform-core": "17.5.0"
@@ -462,12 +462,12 @@
       }
     },
     "node_modules/apify-client": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.15.0.tgz",
-      "integrity": "sha512-c5gtl6dRhY9r7bMsCkmp1dbE8ZEq4CWB2otRtVFqN4rm01SflXRLFuqXvsLqXQ3JCUlVnpMPsqM3XmHGzcbfSQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.19.0.tgz",
+      "integrity": "sha512-cDYwbygx/OplyF9MXTeb70nKwZHQQIp5OodsPeikWrh8sHmfeKWUu9jUUzeiWpHIPcwroYrP7KxA6UDSBGY3kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.25.0",
+        "@apify/consts": "^2.42.0",
         "@apify/log": "^2.2.6",
         "@apify/utilities": "^2.18.0",
         "@crawlee/types": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@apify/consts": "^2.53.3",
     "@apify/utilities": "^2.34.1",
-    "apify-client": "2.15.0",
+    "apify-client": "2.19.0",
     "dayjs": "^1.11.21",
     "lodash": "^4.17.21",
     "zapier-platform-core": "17.5.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "axios": "^1.17.0",
     "diff": "^8.0.3",
     "flatted": "^3.4.2",
+    "form-data": "^4.0.6",
+    "js-yaml": "^4.3.0",
     "lodash": "$lodash",
     "picomatch": "^2.3.2",
     "serialize-javascript": "^7.0.5"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "./node_modules/.bin/eslint ./src --ext .js --fix"
   },
   "engines": {
-    "node": "18",
+    "node": "22",
     "npm": ">=5.6.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "apify-client": "2.19.0",
     "dayjs": "^1.11.21",
     "lodash": "^4.17.21",
-    "zapier-platform-core": "17.5.0"
+    "zapier-platform-core": "19.0.0"
   },
   "devDependencies": {
     "chai": "^4.5.0",
@@ -32,7 +32,7 @@
     "eslint-plugin-promise": "^7.3.0",
     "mocha": "^11.7.6",
     "nock": "^14.0.16",
-    "zapier-platform-schema": "16.5.0"
+    "zapier-platform-schema": "19.0.0"
   },
   "overrides": {
     "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "@apify/consts": "^2.40.0",
-    "@apify/utilities": "^2.15.4",
+    "@apify/consts": "^2.53.3",
+    "@apify/utilities": "^2.34.1",
     "apify-client": "2.15.0",
-    "dayjs": "^1.11.13",
+    "dayjs": "^1.11.21",
     "lodash": "^4.17.21",
     "zapier-platform-core": "17.5.0"
   },
@@ -29,9 +29,9 @@
     "eslint": "^8.42.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-promise": "^7.2.1",
-    "mocha": "^11.0.0",
-    "nock": "^14.0.4",
+    "eslint-plugin-promise": "^7.3.0",
+    "mocha": "^11.7.6",
+    "nock": "^14.0.16",
     "zapier-platform-schema": "16.5.0"
   },
   "overrides": {

--- a/test/apify_helpers.js
+++ b/test/apify_helpers.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 const { expect } = require('chai');
-const FieldSchema = require('zapier-platform-schema/lib/schemas/FieldSchema');
+const FieldSchema = require('zapier-platform-schema/lib/schemas/PlainInputFieldSchema');
 const makeValidator = require('zapier-platform-schema/lib/utils/makeValidator');
 const nock = require('nock');
 const zapier = require('zapier-platform-core');


### PR DESCRIPTION
<html><head></head><body><hr>
<h2>Update outdated npm dependencies</h2>
<p>Dependencies-only PR, no feature changes; any runtime regression can be bisected cleanly. Auth (OAuth2 + PKCE) unchanged. App <code>version</code> and <code>CHANGELOG.md</code> untouched (owned by release workflow).</p>
<blockquote>
<p>Verified locally: mocked suite green, live API tested via <code>zapier-platform invoke</code>. <strong>Not yet tested in Zapier UI</strong> - blocked on <code>push</code> access (collaborator to admin request pending).</p>
</blockquote>
<h3>What changed</h3>

Package | From → To | Notes
-- | -- | --
engines.node | 18 → 22 | Aligned to .nvmrc / CI; required by platform v19
@apify/consts | ^2.40.0 → ^2.53.3 | Verified named exports still resolve
@apify/utilities | ^2.15.4 → ^2.34.1 | Verified named exports still resolve
dayjs | ^1.11.13 → ^1.11.21 | Patch bump
eslint-plugin-promise | ^7.2.1 → ^7.3.0 | Minor bump
mocha | ^11.0.0 → ^11.7.6 | Patch bump
nock | ^14.0.4 → ^14.0.16 | Patch bump
apify-client | 2.15.0 → 2.19.0 (pinned) | 2.16 renamed expiresInMillis → expiresInSecs (unused here). Pinned to last pre-proxy-agent release; 2.20+ breaks nock 14 with no prod benefit.


<p><em>Note:</em> The <code>run-e2e-test</code> CI job has pre-existing failures unrelated to this PR: E2E tests use exact-match <code>.keys()</code> assertions that have drifted behind the live Apify API (extra fields like <code>standby</code>, <code>consoleUrl</code>, <code>usageTotalUsd</code>). Reproduces on <code>master</code>; will be tracked separately. Mocked suite (60/60) is green.</p></body></html>