### PR TITLE
feat: surface approvalUrl for unapproved full-permission Actors

### DIFF
--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -74,6 +74,22 @@ const validateApiResponse = (response, z) => {
             );
         }
 
+        // Handle full-permission Actors that the user has not approved yet.
+        // Approval is a manual action in Apify Console, so retrying won't help - we surface the
+        // approvalUrl (when present) so the user can approve the permissions and run the Zap again.
+        if (errorInfo && errorInfo.error && errorInfo.error.type === 'full-permission-actor-not-approved') {
+            const approvalUrl = errorInfo.error.data && errorInfo.error.data.approvalUrl;
+            const userMessage = approvalUrl
+                ? `${errorMessage} Approve this Actor's permissions here: ${approvalUrl} — then run the Zap again.`
+                : errorMessage;
+            throw new z.errors.Error(
+                // This message is surfaced to the user
+                userMessage,
+                'ActorApprovalRequired',
+                response.status,
+            );
+        }
+
         throw new Error(errorMessage);
     }
 

--- a/test/request_helpers.js
+++ b/test/request_helpers.js
@@ -1,0 +1,101 @@
+/* eslint-env mocha */
+const { EventEmitter } = require('events');
+
+EventEmitter.defaultMaxListeners = 0;
+
+const zapier = require('zapier-platform-core');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const nock = require('nock');
+
+const { randomString } = require('./helpers');
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const App = require('../index');
+
+const appTester = zapier.createAppTester(App);
+
+// These tests exercise the centralized afterResponse middleware (validateApiResponse in
+// src/request_helpers.js). We drive it through the createActorRun perform, but because the error
+// handling is central it covers every run path (actor run, task run, scrape URL).
+describe('validateApiResponse middleware', () => {
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    const runOptions = {
+        build: 'latest',
+        timeoutSecs: 120,
+        memoryMbytes: 1024,
+    };
+
+    const getBundle = (actorId) => ({
+        authData: {
+            access_token: 'test-token',
+        },
+        inputData: {
+            actorId,
+            // Passing inputBody skips the input-schema fetch, so the run POST is the only request.
+            inputBody: '',
+            runSync: false,
+            ...runOptions,
+        },
+    });
+
+    it('surfaces the approvalUrl for unapproved full-permission Actors', async () => {
+        const testActorId = randomString();
+        const approvalUrl = `https://console.apify.com/actors/${testActorId}?approvePermissions=true`;
+
+        const scope = nock('https://api.apify.com');
+        scope.post(`/v2/acts/${testActorId}/runs`)
+            .query({
+                timeout: runOptions.timeoutSecs,
+                memory: runOptions.memoryMbytes,
+                build: runOptions.build,
+            })
+            .reply(403, {
+                error: {
+                    type: 'full-permission-actor-not-approved',
+                    message: 'This Actor requires full access to your account. You must approve its permissions before running it.',
+                    data: { approvalUrl },
+                },
+            });
+
+        const promise = appTester(App.creates.createActorRun.operation.perform, getBundle(testActorId));
+
+        await expect(promise).to.be.rejectedWith(/approvePermissions=true/);
+        // It must be a z.errors.Error (halts the step), not a bare Error.
+        await expect(promise).to.be.rejectedWith(zapier.errors.Error);
+
+        scope.done();
+    });
+
+    it('throws a clear error when full-permission type matches but approvalUrl is missing', async () => {
+        const testActorId = randomString();
+        const message = 'This Actor requires full access to your account. You must approve its permissions before running it.';
+
+        const scope = nock('https://api.apify.com');
+        scope.post(`/v2/acts/${testActorId}/runs`)
+            .query({
+                timeout: runOptions.timeoutSecs,
+                memory: runOptions.memoryMbytes,
+                build: runOptions.build,
+            })
+            .reply(403, {
+                error: {
+                    type: 'full-permission-actor-not-approved',
+                    message,
+                    // No data.approvalUrl on purpose.
+                },
+            });
+
+        const promise = appTester(App.creates.createActorRun.operation.perform, getBundle(testActorId));
+
+        await expect(promise).to.be.rejectedWith(zapier.errors.Error);
+        await expect(promise).to.be.rejectedWith(message);
+
+        scope.done();
+    });
+});


### PR DESCRIPTION
---

### Problem

The Apify platform requires user approval before running a *full-permission* Actor. An unapproved run returns **HTTP 403** with type `full-permission-actor-not-approved` and an `approvalUrl`. The integration surfaced this as a generic, dead-end error with no way to know approval was needed or where to do it.

> Verified locally: mocked suite green, live API tested via `zapier-platform invoke`. **Not yet tested in Zapier UI** - blocked on `push` access (collaborator to admin request pending).

### Fix

One branch added to **`validateApiResponse`** in `src/request_helpers.js` (the shared `afterResponse` middleware all Apify responses flow through). Detects the `full-permission-actor-not-approved` type and throws a `z.errors.Error` with the `approvalUrl` appended, giving the user a clear, clickable path to approve and re-run. Covers **every run path** (Actor run, task run, scrape URL) without touching each create.

**Why `z.errors.Error`:** halts the step and shows the message (same as the existing token-error branch). Not `RetryableError` (approval is manual, retrying won't help). Not `RefreshAuthError` (not a credential problem, and the repo deliberately avoids it). Defensive: if the type matches but `approvalUrl` is missing, it still throws the explanatory error rather than falling through to the generic one.

### Tests

New `test/request_helpers.js` (nock + `createAppTester` + chai-as-promised), driven through `createActorRun.perform`:
- 403 **with** `approvalUrl` → rejects with `z.errors.Error` matching `/approvePermissions=true/`.
- 403 with the type but **no** `approvalUrl` → still rejects with explanatory message, no crash.

### Verification

- Mocked: suite went 58→60 passing, **zero** new failures (11 failures are pre-existing dependency/sample-shape drift, confirmed by stashing changes). Lint clean. `validate --without-style` sound.
- **E2E:** reproducing live needs a real unapproved full-permission Actor, not practical in CI; deferred. Mocked tests cover behavior.

### Scope

Error-path only: `src/request_helpers.js` + one test file. No new actions/triggers, no auth changes, no unrelated refactors.