### PR TITLE
feat: 122 zapier add Get Actor Run by ID search

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const scrapeSingleUrlCreate = require('./src/creates/scrape_single_url');
 const setValueCreate = require('./src/creates/set_value');
 const taskLastRunSearch = require('./src/searches/task_last_run');
 const actorLastRunSearch = require('./src/searches/actor_last_run');
+const getRunSearch = require('./src/searches/get_run');
 const getValueSearch = require('./src/searches/get_value');
 const fetchItemsSearch = require('./src/searches/fetch_items');
 
@@ -59,6 +60,7 @@ const App = {
     searches: {
         [taskLastRunSearch.key]: taskLastRunSearch,
         [actorLastRunSearch.key]: actorLastRunSearch,
+        [getRunSearch.key]: getRunSearch,
         [getValueSearch.perform.key]: getValueSearch.perform,
         [fetchItemsSearch.key]: fetchItemsSearch,
     },

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -7,7 +7,7 @@ const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRA
     ACTOR_RUN_TERMINAL_EVENT_TYPES,
     DATASET_MAX_SIZE_MARGIN,
 } = require('./consts');
-const { wrapRequestWithRetries } = require('./request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('./request_helpers');
 
 // Key of field to use internally to compute changes in fields.
 const ACTOR_ID_REFERENCE_FIELD_KEY = 'referenceActorId';
@@ -258,7 +258,7 @@ const getOrCreateKeyValueStore = async (z, storeIdOrName) => {
         });
         store = storeResponse.data;
     } catch (err) {
-        if (!err.message.includes('not found')) throw err;
+        if (!isNotFoundError(err)) throw err;
     }
 
     // The second creates store with name, in case storeId not found.

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -41,8 +41,9 @@ const getActorDatasetOutputFields = async (z, bundle) => {
             },
         });
     } catch (err) {
-        // 404 status = There is not successful run yet.
-        if (err.status !== 404) {
+        // A "not found" error means there is no successful run yet; a normal case, so do not log it.
+        const message = err?.message ?? '';
+        if (!message.includes('not found')) {
             z.console.error('Error while fetching dataset items', err);
         }
         // Return default output fields, if there is no successful run yet or any other error.
@@ -67,8 +68,9 @@ const getRunDatasetOutputFields = async (z, bundle) => {
             url: `${APIFY_API_ENDPOINTS.actorRuns}/${runId}`,
         });
     } catch (err) {
-        // 404 status = The run was not found.
-        if (err.status !== 404) {
+        // Ignore "not found" errors; run may not exist yet.
+        const message = err?.message ?? '';
+        if (!message.includes('not found')) {
             z.console.error('Error while fetching run for output fields', err);
         }
         // Return default output fields, if the run does not exist or any other error.
@@ -92,8 +94,9 @@ const getTaskDatasetOutputFields = async (z, bundle) => {
             },
         });
     } catch (err) {
-        // 404 status = There is not successful run yet.
-        if (err.status !== 404) {
+        // A "not found" error means there is no successful run yet; a normal case, so do not log it.
+        const message = err?.message ?? '';
+        if (!message.includes('not found')) {
             z.console.error('Error while fetching dataset items', err);
         }
         // Return default output fields, if there is no successful run yet or any other error.

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -52,6 +52,35 @@ const getActorDatasetOutputFields = async (z, bundle) => {
     return getDatasetItemsOutputFields(z, run.defaultDatasetId, actorId);
 };
 
+/**
+ * Loads dynamic dataset output fields for a search/action that is identified by a run ID
+ * (e.g. "Get Actor Run by ID"), where the Actor ID is not part of the input. It fetches the
+ * run itself to resolve its default dataset and derives the fields from that dataset's items.
+ */
+const getRunDatasetOutputFields = async (z, bundle) => {
+    const { runId } = bundle.inputData;
+    if (!runId) return [];
+
+    let runResponse;
+    try {
+        runResponse = await wrapRequestWithRetries(z.request, {
+            url: `${APIFY_API_ENDPOINTS.actorRuns}/${runId}`,
+        });
+    } catch (err) {
+        // 404 status = The run was not found.
+        if (err.status !== 404) {
+            z.console.error('Error while fetching run for output fields', err);
+        }
+        // Return default output fields, if the run does not exist or any other error.
+        return [];
+    }
+
+    const { data: run } = runResponse;
+    if (!run || !run.defaultDatasetId) return [];
+
+    return getDatasetItemsOutputFields(z, run.defaultDatasetId, run.actId);
+};
+
 const getTaskDatasetOutputFields = async (z, bundle) => {
     const { taskId } = bundle.inputData;
     let lastSuccessDatasetItems;
@@ -77,5 +106,6 @@ const getTaskDatasetOutputFields = async (z, bundle) => {
 module.exports = {
     getDatasetItemsOutputFields,
     getActorDatasetOutputFields,
+    getRunDatasetOutputFields,
     getTaskDatasetOutputFields,
 };

--- a/src/output_fields.js
+++ b/src/output_fields.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const { ACTOR_JOB_STATUSES } = require('@apify/consts');
 const { getDatasetItems } = require('./apify_helpers');
-const { wrapRequestWithRetries } = require('./request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('./request_helpers');
 const { APIFY_API_ENDPOINTS } = require('./consts');
 const { convertPlainObjectToFieldSchema } = require('./zapier_helpers');
 
@@ -41,12 +41,9 @@ const getActorDatasetOutputFields = async (z, bundle) => {
             },
         });
     } catch (err) {
-        // A "not found" error means there is no successful run yet; a normal case, so do not log it.
-        const message = err?.message ?? '';
-        if (!message.includes('not found')) {
+        if (!isNotFoundError(err)) {
             z.console.error('Error while fetching dataset items', err);
         }
-        // Return default output fields, if there is no successful run yet or any other error.
         return [];
     }
     const { data: run } = lastSuccessDatasetItems;
@@ -68,12 +65,9 @@ const getRunDatasetOutputFields = async (z, bundle) => {
             url: `${APIFY_API_ENDPOINTS.actorRuns}/${runId}`,
         });
     } catch (err) {
-        // Ignore "not found" errors; run may not exist yet.
-        const message = err?.message ?? '';
-        if (!message.includes('not found')) {
+        if (!isNotFoundError(err)) {
             z.console.error('Error while fetching run for output fields', err);
         }
-        // Return default output fields, if the run does not exist or any other error.
         return [];
     }
 
@@ -94,12 +88,9 @@ const getTaskDatasetOutputFields = async (z, bundle) => {
             },
         });
     } catch (err) {
-        // A "not found" error means there is no successful run yet; a normal case, so do not log it.
-        const message = err?.message ?? '';
-        if (!message.includes('not found')) {
+        if (!isNotFoundError(err)) {
             z.console.error('Error while fetching dataset items', err);
         }
-        // Return default output fields, if there is no successful run yet or any other error.
         return [];
     }
     const { data: run } = lastSuccessDatasetItems;

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -119,8 +119,6 @@ const waitForRunToFinish = async (request, runId, timeoutSecs) => {
 
 /**
  * Checks whether an error represents a "not found" API response.
- * @param {Error} err
- * @returns {boolean}
  */
 const isNotFoundError = (err) => (err?.message ?? '').includes('not found');
 

--- a/src/request_helpers.js
+++ b/src/request_helpers.js
@@ -117,7 +117,15 @@ const waitForRunToFinish = async (request, runId, timeoutSecs) => {
     throw new Error(`Timeout of ${timeoutSecs} seconds reached for run ${runId}`);
 };
 
+/**
+ * Checks whether an error represents a "not found" API response.
+ * @param {Error} err
+ * @returns {boolean}
+ */
+const isNotFoundError = (err) => (err?.message ?? '').includes('not found');
+
 module.exports = {
+    isNotFoundError,
     parseDataApiObject,
     setApifyRequestHeaders,
     validateApiResponse,

--- a/src/searches/actor_last_run.js
+++ b/src/searches/actor_last_run.js
@@ -6,7 +6,7 @@ const {
     ACTOR_RUN_STATUSES,
 } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
-const { wrapRequestWithRetries } = require('../request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('../request_helpers');
 const { getActorDatasetOutputFields } = require('../output_fields');
 
 const getLastActorRun = async (z, bundle) => {
@@ -19,7 +19,7 @@ const getLastActorRun = async (z, bundle) => {
             params: status ? { status } : {},
         });
     } catch (err) {
-        if (err.message.includes('not found')) return [];
+        if (isNotFoundError(err)) return [];
 
         throw err;
     }

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const { APIFY_API_ENDPOINTS, DATASET_PUBLISH_FIELDS,
     DATASET_OUTPUT_FIELDS, DATASET_SAMPLE } = require('../consts');
-const { wrapRequestWithRetries } = require('../request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('../request_helpers');
 const { getDatasetItems } = require('../apify_helpers');
 const { getDatasetItemsOutputFields } = require('../output_fields');
 
@@ -14,7 +14,7 @@ const findDatasetByNameOrId = async (z, datasetIdOrName) => {
         });
         return datasetResponse.data;
     } catch (err) {
-        if (!err.message.includes('not found')) throw err;
+        if (!isNotFoundError(err)) throw err;
     }
     // The second creates dataset with name, in case datasetId not found.
     const storeResponse = await wrapRequestWithRetries(z.request, {

--- a/src/searches/get_run.js
+++ b/src/searches/get_run.js
@@ -4,7 +4,7 @@ const {
     APIFY_API_ENDPOINTS,
 } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
-const { wrapRequestWithRetries } = require('../request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('../request_helpers');
 const { getRunDatasetOutputFields } = require('../output_fields');
 
 const getActorRunById = async (z, bundle) => {
@@ -16,7 +16,7 @@ const getActorRunById = async (z, bundle) => {
             url: `${APIFY_API_ENDPOINTS.actorRuns}/${runId}`,
         });
     } catch (err) {
-        if (err.message.includes('not found')) return [];
+        if (isNotFoundError(err)) return [];
 
         throw err;
     }

--- a/src/searches/get_run.js
+++ b/src/searches/get_run.js
@@ -1,0 +1,58 @@
+const {
+    ACTOR_RUN_SAMPLE,
+    ACTOR_RUN_OUTPUT_FIELDS,
+    APIFY_API_ENDPOINTS,
+} = require('../consts');
+const { enrichActorRun } = require('../apify_helpers');
+const { wrapRequestWithRetries } = require('../request_helpers');
+const { getActorDatasetOutputFields } = require('../output_fields');
+
+const getActorRunById = async (z, bundle) => {
+    const { runId } = bundle.inputData;
+    let runResponse;
+
+    try {
+        runResponse = await wrapRequestWithRetries(z.request, {
+            url: `${APIFY_API_ENDPOINTS.actorRuns}/${runId}`,
+        });
+    } catch (err) {
+        if (err.message.includes('not found')) return [];
+
+        throw err;
+    }
+
+    const enrichRun = await enrichActorRun(z, bundle.authData.access_token, runResponse.data);
+    return [enrichRun];
+};
+
+module.exports = {
+    key: 'getActorRunById',
+    noun: 'Actor Run',
+    display: {
+        label: 'Get Actor Run by ID',
+        description: 'Retrieves details and results of a specific Actor run by its ID. '
+            + 'Use this to check the status or fetch the output of a run started in a previous step. '
+            + 'The run can be triggered by Run Actor or Run Task.',
+    },
+
+    operation: {
+        inputFields: [
+            {
+                label: 'Run ID',
+                key: 'runId',
+                required: true,
+                type: 'string',
+                helpText: 'The ID of the Actor run to retrieve, e.g. `HG7ML7M8z78YcAPEB`. '
+                    + 'You typically get this from a previous **Run Actor** or **Run Task** step.',
+            },
+        ],
+
+        perform: getActorRunById,
+
+        sample: ACTOR_RUN_SAMPLE,
+        outputFields: [
+            ...ACTOR_RUN_OUTPUT_FIELDS,
+            getActorDatasetOutputFields,
+        ],
+    },
+};

--- a/src/searches/get_run.js
+++ b/src/searches/get_run.js
@@ -5,7 +5,7 @@ const {
 } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
-const { getActorDatasetOutputFields } = require('../output_fields');
+const { getRunDatasetOutputFields } = require('../output_fields');
 
 const getActorRunById = async (z, bundle) => {
     const { runId } = bundle.inputData;
@@ -52,7 +52,7 @@ module.exports = {
         sample: ACTOR_RUN_SAMPLE,
         outputFields: [
             ...ACTOR_RUN_OUTPUT_FIELDS,
-            getActorDatasetOutputFields,
+            getRunDatasetOutputFields,
         ],
     },
 };

--- a/src/searches/task_last_run.js
+++ b/src/searches/task_last_run.js
@@ -6,7 +6,7 @@ const {
     ACTOR_RUN_STATUSES,
 } = require('../consts');
 const { enrichActorRun } = require('../apify_helpers');
-const { wrapRequestWithRetries } = require('../request_helpers');
+const { wrapRequestWithRetries, isNotFoundError } = require('../request_helpers');
 const { getTaskDatasetOutputFields } = require('../output_fields');
 
 const getLastTaskRun = async (z, bundle) => {
@@ -19,7 +19,7 @@ const getLastTaskRun = async (z, bundle) => {
             params: status ? { status } : {},
         });
     } catch (err) {
-        if (err.message.includes('not found')) return [];
+        if (isNotFoundError(err)) return [];
 
         throw err;
     }

--- a/test/searches/get_run.js
+++ b/test/searches/get_run.js
@@ -1,0 +1,111 @@
+/* eslint-env mocha */
+const zapier = require('zapier-platform-core');
+const { ACTOR_JOB_STATUSES } = require('@apify/consts');
+const { expect } = require('chai');
+const nock = require('nock');
+const { apifyClient, TEST_USER_TOKEN, createAndBuildActor, getMockRun, mockDatasetPublicUrl } = require('../helpers');
+
+const App = require('../../index');
+const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
+
+const appTester = zapier.createAppTester(App);
+
+describe('search get actor run by ID', () => {
+    let testActorId = 'test_actor-id';
+    let testRunId = 'test_run-id';
+
+    before(async function () {
+        if (TEST_USER_TOKEN) {
+            this.timeout(240000); // We need time to build and run actor
+            // Create and run actor for testing
+            const actor = await createAndBuildActor();
+            testActorId = actor.id;
+            const run = await apifyClient.actor(testActorId).call({ waitSecs: 120 });
+            testRunId = run.id;
+        }
+    });
+
+    after(async () => {
+        if (TEST_USER_TOKEN) {
+            await apifyClient.actor(testActorId).delete();
+        }
+    });
+
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
+    it('returns empty array when run not found', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                runId: 'non-existing-run-id',
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/actor-runs/non-existing-run-id')
+                .reply(404, {
+                    error: {
+                        type: 'record-not-found',
+                        message: 'Run was not found',
+                    },
+                });
+        }
+
+        const testResult = await appTester(App.searches.getActorRunById.operation.perform, bundle);
+
+        expect(testResult.length).to.be.eql(0);
+
+        scope?.done();
+    });
+
+    it('work', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                runId: testRunId,
+            },
+        };
+
+        let actorRun;
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            actorRun = getMockRun({ id: testRunId, status: ACTOR_JOB_STATUSES.SUCCEEDED });
+            scope = nock('https://api.apify.com');
+            scope.get(`/v2/actor-runs/${testRunId}`)
+                .reply(200, {
+                    data: actorRun,
+                });
+
+            scope.get(`/v2/key-value-stores/${actorRun.defaultKeyValueStoreId}/records/OUTPUT`)
+                .reply(200, KEY_VALUE_STORE_SAMPLE);
+
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
+                .query({ limit: 1, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
+                .query({ limit: 100, clean: true })
+                .reply(200, [{ foo: 'bar' }]);
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}`)
+                .reply(200, mockDatasetPublicUrl(actorRun.defaultDatasetId));
+        } else {
+            actorRun = { id: testRunId };
+        }
+
+        const testResult = await appTester(App.searches.getActorRunById.operation.perform, bundle);
+
+        expect(testResult.length).to.be.eql(1);
+        expect(testResult[0].id).to.be.eql(actorRun.id);
+
+        scope?.done();
+    }).timeout(240000);
+});

--- a/test/searches/get_run.js
+++ b/test/searches/get_run.js
@@ -145,4 +145,36 @@ describe('search get actor run by ID', () => {
 
         scope?.done();
     }).timeout(240000);
+
+    it('returns empty dynamic output fields when the run is not found', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                runId: 'non-existing-run-id',
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/actor-runs/non-existing-run-id')
+                .reply(404, {
+                    error: {
+                        type: 'record-not-found',
+                        message: 'Run was not found',
+                    },
+                });
+        }
+
+        const { outputFields } = App.searches.getActorRunById.operation;
+        const getDynamicOutputFields = outputFields[outputFields.length - 1];
+        const fields = await appTester(getDynamicOutputFields, bundle);
+
+        expect(fields).to.be.an('array');
+        expect(fields.length).to.be.eql(0);
+
+        scope?.done();
+    });
 });

--- a/test/searches/get_run.js
+++ b/test/searches/get_run.js
@@ -66,7 +66,7 @@ describe('search get actor run by ID', () => {
         scope?.done();
     });
 
-    it('work', async () => {
+    it('returns enriched run for a valid run ID', async () => {
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,
@@ -105,6 +105,43 @@ describe('search get actor run by ID', () => {
 
         expect(testResult.length).to.be.eql(1);
         expect(testResult[0].id).to.be.eql(actorRun.id);
+
+        scope?.done();
+    }).timeout(240000);
+
+    it('derives dynamic dataset output fields from the run ID', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                runId: testRunId,
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            const actorRun = getMockRun({ id: testRunId, status: ACTOR_JOB_STATUSES.SUCCEEDED });
+            scope = nock('https://api.apify.com');
+            // The output-fields function resolves the run first to find its default dataset.
+            scope.get(`/v2/actor-runs/${testRunId}`)
+                .reply(200, {
+                    data: actorRun,
+                });
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}/items`)
+                .query({ limit: 10, clean: true })
+                .reply(200, [{ myField: 'value' }]);
+            scope.get(`/v2/datasets/${actorRun.defaultDatasetId}`)
+                .reply(200, mockDatasetPublicUrl(actorRun.defaultDatasetId));
+        }
+
+        // The dynamic output fields function is the last entry in the outputFields array.
+        const { outputFields } = App.searches.getActorRunById.operation;
+        const getDynamicOutputFields = outputFields[outputFields.length - 1];
+        const fields = await appTester(getDynamicOutputFields, bundle);
+
+        expect(fields).to.be.an('array');
+        expect(fields.some((field) => field.key.startsWith('datasetItems[]'))).to.be.eql(true);
 
         scope?.done();
     }).timeout(240000);


### PR DESCRIPTION
<html><head></head><body><hr>
<h2>What &amp; why</h2>
<p>Part of #121 (Zapier Agents compatibility). Adds a <strong>Get Actor Run by ID</strong> search, the building block for async agent orchestration: <strong>Run Actor/Task</strong> returns a run ID, and this search later checks its status/retrieves output. The existing <strong>Find Last Actor Run</strong> only returns the most recent run, which is fragile with multiple concurrent runs.</p>
<blockquote>
<p>Verified locally: mocked suite green, live API tested via <code>zapier-platform invoke</code>. <strong>Not yet tested in Zapier UI</strong> - blocked on <code>push</code> access (collaborator to admin request pending).</p>
</blockquote>
<h2>Changes</h2>
<ul>
<li><strong><code>src/searches/get_run.js</code></strong> - <code>GET /v2/actor-runs/{runId}</code> via <code>wrapRequestWithRetries</code>; 404 → <code>[]</code> (miss = success, existing <code>'not found'</code> convention); else <code>enrichActorRun(...)</code> → <code>[run]</code> (inlined dataset items, KV <code>OUTPUT</code>, <code>detailsPageUrl</code>). Reuses <code>ACTOR_RUN_SAMPLE</code> + <code>ACTOR_RUN_OUTPUT_FIELDS</code> so output stays chainable (raw <code>id</code>, <code>defaultDatasetId</code>, etc. preserved).</li>
<li><strong><code>src/output_fields.js</code></strong> - new <code>getRunDatasetOutputFields</code>: derives dynamic dataset columns from the run's own <code>defaultDatasetId</code>. The actor-based helper couldn't, since this search takes only <code>runId</code> (not <code>actorId</code>).</li>
<li><strong><code>index.js</code></strong> - registered.</li>
<li><strong><code>test/searches/get_run.js</code></strong> - 3 tests: found case, 404 → <code>[]</code>, dynamic output fields.</li>
</ul>
<h3>Action metadata</h3>

Field | Value
-- | --
key | getActorRunById
noun / label | Actor Run / Get Actor Run by ID
description | Retrieves details and results of a specific Actor run by its ID. Use to check status or fetch output of a run started in a previous step (via Run Actor or Run Task).


<p><strong>Input:</strong> <code>runId</code> (required, string; example ID in helpText).</p>
<h2>Testing</h2>
<ul>
<li>Mocked: <code>63 passing / 8 pending / 0 failing</code>. Lint clean. <code>validate --without-style</code> sound.</li>
<li>Live: existing run → enriched <code>[run]</code>, missing run → <code>[]</code>.</li>
<li>Pre-existing E2E failures (shape drift, token-scope) unrelated.</li>
</ul>
<h2>Notes</h2>
<p>No renamed keys, no auth changes, no version/CHANGELOG edits. Targets epic branch.</p></body></html>