### PR TITLE
feat: 127 zapier new search get actor details

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const taskLastRunSearch = require('./src/searches/task_last_run');
 const actorLastRunSearch = require('./src/searches/actor_last_run');
 const getValueSearch = require('./src/searches/get_value');
 const fetchItemsSearch = require('./src/searches/fetch_items');
+const getActorSearch = require('./src/searches/get_actor');
 
 /**
  * Apify APP definition
@@ -61,6 +62,7 @@ const App = {
         [actorLastRunSearch.key]: actorLastRunSearch,
         [getValueSearch.perform.key]: getValueSearch.perform,
         [fetchItemsSearch.key]: fetchItemsSearch,
+        [getActorSearch.key]: getActorSearch,
     },
 
     // If you want your creates to show up, you better include it here!

--- a/src/consts.js
+++ b/src/consts.js
@@ -228,8 +228,10 @@ const ACTOR_SAMPLE = {
     username: 'apify',
     isPublic: true,
     actorPermissionLevel: 'LIMITED_PERMISSIONS',
+    createdAt: '2019-07-08T11:27:57.401Z',
+    modifiedAt: '2019-07-08T14:01:05.546Z',
+    standbyUrl: 'https://web-scraper.apify.actor',
     stats: {
-        totalBuilds: 9,
         totalRuns: 16,
         totalUsers: 6,
         lastRunStartedAt: '2019-07-08T14:01:05.546Z',
@@ -238,6 +240,12 @@ const ACTOR_SAMPLE = {
         build: 'latest',
         timeoutSecs: 3600,
         memoryMbytes: 2048,
+    },
+    taggedBuilds: {
+        latest: {
+            buildId: 'z2EryhbfhgSyqj6Hn',
+            buildNumber: '0.0.2',
+        },
     },
 };
 
@@ -249,6 +257,9 @@ const ACTOR_OUTPUT_FIELDS = [
     { key: 'username', label: 'Username', type: 'string' },
     { key: 'isPublic', label: 'Is public', type: 'boolean' },
     { key: 'actorPermissionLevel', label: 'Actor permission level', type: 'string' },
+    { key: 'createdAt', label: 'Created at' },
+    { key: 'modifiedAt', label: 'Modified at' },
+    { key: 'standbyUrl', label: 'Standby URL', type: 'string' },
     { key: 'stats__totalRuns', label: 'Total runs', type: 'number' },
     { key: 'stats__totalUsers', label: 'Total users', type: 'number' },
     { key: 'stats__lastRunStartedAt', label: 'Last run started at' },

--- a/src/consts.js
+++ b/src/consts.js
@@ -220,6 +220,43 @@ const TASK_RUN_SAMPLE = {
 
 const TASK_RUN_OUTPUT_FIELDS = ACTOR_RUN_OUTPUT_FIELDS.concat([{ key: 'actorTaskId', label: 'Actor task ID', type: 'string' }]);
 
+const ACTOR_SAMPLE = {
+    id: 'zdc3Pyhyz3m8vjDeM',
+    name: 'web-scraper',
+    title: 'Web Scraper',
+    description: 'Crawls arbitrary websites using a browser and extracts structured data from web pages.',
+    username: 'apify',
+    isPublic: true,
+    actorPermissionLevel: 'LIMITED_PERMISSIONS',
+    stats: {
+        totalBuilds: 9,
+        totalRuns: 16,
+        totalUsers: 6,
+        lastRunStartedAt: '2019-07-08T14:01:05.546Z',
+    },
+    defaultRunOptions: {
+        build: 'latest',
+        timeoutSecs: 3600,
+        memoryMbytes: 2048,
+    },
+};
+
+const ACTOR_OUTPUT_FIELDS = [
+    { key: 'id', label: 'ID', type: 'string' },
+    { key: 'name', label: 'Name', type: 'string' },
+    { key: 'title', label: 'Title', type: 'string' },
+    { key: 'description', label: 'Description', type: 'string' },
+    { key: 'username', label: 'Username', type: 'string' },
+    { key: 'isPublic', label: 'Is public', type: 'boolean' },
+    { key: 'actorPermissionLevel', label: 'Actor permission level', type: 'string' },
+    { key: 'stats__totalRuns', label: 'Total runs', type: 'number' },
+    { key: 'stats__totalUsers', label: 'Total users', type: 'number' },
+    { key: 'stats__lastRunStartedAt', label: 'Last run started at' },
+    { key: 'defaultRunOptions__build', label: 'Default build', type: 'string' },
+    { key: 'defaultRunOptions__timeoutSecs', label: 'Default timeout (seconds)', type: 'number' },
+    { key: 'defaultRunOptions__memoryMbytes', label: 'Default memory (MB)', type: 'number' },
+];
+
 const DATASET_SAMPLE = {
     id: 'fYYRaBM5FSoCZ2Tf9',
     name: 'dataset-sample',
@@ -334,6 +371,8 @@ module.exports = {
     ACTOR_RUN_OUTPUT_FIELDS,
     TASK_RUN_SAMPLE,
     TASK_RUN_OUTPUT_FIELDS,
+    ACTOR_SAMPLE,
+    ACTOR_OUTPUT_FIELDS,
     DEFAULT_KEY_VALUE_STORE_KEYS,
     DEFAULT_PAGINATION_LIMIT,
     LEGACY_PHANTOM_JS_CRAWLER_ID,

--- a/src/searches/get_actor.js
+++ b/src/searches/get_actor.js
@@ -6,6 +6,10 @@ const {
 } = require('../consts');
 const { wrapRequestWithRetries } = require('../request_helpers');
 
+// Deep property paths passed to `_.pick`. Nested objects (`stats`, `defaultRunOptions`) are
+// trimmed to the sub-fields we actually expose, so the output matches the declared output fields
+// instead of leaking noise (review ratings, per-day user counts, `restartOnError`, …).
+// `taggedBuilds` is picked whole because its keys are per-Actor build tags (dynamic, not fixed).
 const CURATED_ACTOR_FIELDS = [
     'id',
     'name',
@@ -14,8 +18,16 @@ const CURATED_ACTOR_FIELDS = [
     'username',
     'isPublic',
     'actorPermissionLevel',
-    'stats',
-    'defaultRunOptions',
+    'createdAt',
+    'modifiedAt',
+    'standbyUrl',
+    'stats.totalRuns',
+    'stats.totalUsers',
+    'stats.lastRunStartedAt',
+    'defaultRunOptions.build',
+    'defaultRunOptions.timeoutSecs',
+    'defaultRunOptions.memoryMbytes',
+    'taggedBuilds',
 ];
 
 const getActorDetails = async (z, bundle) => {
@@ -38,6 +50,13 @@ const getActorDetails = async (z, bundle) => {
     }
 
     const actor = _.pick(actorResponse.data, CURATED_ACTOR_FIELDS);
+
+    // `taggedBuilds` is keyed by dynamic build tags (e.g. `latest`, `version-3`); keep only the
+    // build ID and version per tag and drop the noise (`finishedAt`, `buildNumberInt`).
+    if (actor.taggedBuilds) {
+        actor.taggedBuilds = _.mapValues(actor.taggedBuilds, (build) => _.pick(build, ['buildId', 'buildNumber']));
+    }
+
     return [actor];
 };
 
@@ -47,7 +66,7 @@ module.exports = {
     display: {
         label: 'Get Actor Details',
         description: 'Retrieves metadata and description for a specific Actor, including its title, description, '
-            + 'and whether it is publicly available. Use this to confirm an actor is suitable before running it.',
+            + 'and whether it is publicly available. Use this to confirm an Actor is suitable before running it.',
     },
 
     operation: {

--- a/src/searches/get_actor.js
+++ b/src/searches/get_actor.js
@@ -23,7 +23,8 @@ const getActorDetails = async (z, bundle) => {
 
     // The REST path expects the `<username>~<actorName>` form, so a `username/name` slug
     // (e.g. `apify/web-scraper`) must have its `/` replaced with `~`. Plain Actor IDs pass through.
-    const normalizedActorId = actorId.replace('/', '~');
+    // Trim and replace all slashes so stray whitespace or a trailing `/` can't malform the path.
+    const normalizedActorId = actorId.trim().replaceAll('/', '~');
 
     let actorResponse;
     try {

--- a/src/searches/get_actor.js
+++ b/src/searches/get_actor.js
@@ -1,0 +1,68 @@
+const _ = require('lodash');
+const {
+    ACTOR_SAMPLE,
+    ACTOR_OUTPUT_FIELDS,
+    APIFY_API_ENDPOINTS,
+} = require('../consts');
+const { wrapRequestWithRetries } = require('../request_helpers');
+
+const CURATED_ACTOR_FIELDS = [
+    'id',
+    'name',
+    'title',
+    'description',
+    'username',
+    'isPublic',
+    'actorPermissionLevel',
+    'stats',
+    'defaultRunOptions',
+];
+
+const getActorDetails = async (z, bundle) => {
+    const { actorId } = bundle.inputData;
+
+    // The REST path expects the `<username>~<actorName>` form, so a `username/name` slug
+    // (e.g. `apify/web-scraper`) must have its `/` replaced with `~`. Plain Actor IDs pass through.
+    const normalizedActorId = actorId.replace('/', '~');
+
+    let actorResponse;
+    try {
+        actorResponse = await wrapRequestWithRetries(z.request, {
+            url: `${APIFY_API_ENDPOINTS.actors}/${normalizedActorId}`,
+        });
+    } catch (err) {
+        if (err.message.includes('not found')) return [];
+
+        throw err;
+    }
+
+    const actor = _.pick(actorResponse.data, CURATED_ACTOR_FIELDS);
+    return [actor];
+};
+
+module.exports = {
+    key: 'getActorDetails',
+    noun: 'Actor',
+    display: {
+        label: 'Get Actor Details',
+        description: 'Retrieves metadata and description for a specific Actor, including its title, description, '
+            + 'and whether it is publicly available. Use this to confirm an actor is suitable before running it.',
+    },
+
+    operation: {
+        inputFields: [
+            {
+                label: 'Actor',
+                key: 'actorId',
+                required: true,
+                type: 'string',
+                helpText: 'Actor ID or username/name slug, e.g. `apify/web-scraper`.',
+            },
+        ],
+
+        perform: getActorDetails,
+
+        sample: ACTOR_SAMPLE,
+        outputFields: ACTOR_OUTPUT_FIELDS,
+    },
+};

--- a/test/searches/get_actor.js
+++ b/test/searches/get_actor.js
@@ -1,0 +1,109 @@
+/* eslint-env mocha */
+const zapier = require('zapier-platform-core');
+const { expect } = require('chai');
+const nock = require('nock');
+const { TEST_USER_TOKEN } = require('../helpers');
+
+const App = require('../../index');
+const { ACTOR_SAMPLE } = require('../../src/consts');
+
+const appTester = zapier.createAppTester(App);
+
+describe('search get actor details', () => {
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
+    it('returns empty array when actor not found', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                actorId: 'non-existing-actor-id',
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/acts/non-existing-actor-id')
+                .reply(404, {
+                    error: {
+                        type: 'record-not-found',
+                        message: 'Actor was not found',
+                    },
+                });
+        }
+
+        const testResult = await appTester(App.searches.getActorDetails.operation.perform, bundle);
+
+        expect(testResult.length).to.be.eql(0);
+
+        scope?.done();
+    });
+
+    it('returns curated actor when found by ID', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                actorId: TEST_USER_TOKEN ? 'apify/web-scraper' : ACTOR_SAMPLE.id,
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get(`/v2/acts/${ACTOR_SAMPLE.id}`)
+                .reply(200, {
+                    // Extra fields (e.g. versions, userId) that must be dropped by the curation.
+                    data: { ...ACTOR_SAMPLE, userId: 'wRsJZtadYvn4mBZmm', versions: [{ versionNumber: '0.1' }] },
+                });
+        }
+
+        const testResult = await appTester(App.searches.getActorDetails.operation.perform, bundle);
+
+        expect(testResult.length).to.be.eql(1);
+        expect(testResult[0].id).to.be.a('string');
+        expect(testResult[0].name).to.be.a('string');
+        expect(testResult[0].username).to.be.a('string');
+        // Non-curated fields must not leak through.
+        expect(testResult[0].versions).to.be.eql(undefined);
+        expect(testResult[0].userId).to.be.eql(undefined);
+
+        scope?.done();
+    });
+
+    it('normalizes username/name slug to ~ in the request path', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                actorId: 'apify/web-scraper',
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/acts/apify~web-scraper')
+                .reply(200, {
+                    data: { ...ACTOR_SAMPLE, name: 'web-scraper', username: 'apify' },
+                });
+        }
+
+        const testResult = await appTester(App.searches.getActorDetails.operation.perform, bundle);
+
+        expect(testResult.length).to.be.eql(1);
+        expect(testResult[0].username).to.be.eql('apify');
+        expect(testResult[0].name).to.be.eql('web-scraper');
+
+        // In mocked mode a satisfied scope proves the `apify~web-scraper` path was hit.
+        scope?.done();
+    });
+});

--- a/test/searches/get_actor.js
+++ b/test/searches/get_actor.js
@@ -45,7 +45,7 @@ describe('search get actor details', () => {
         scope?.done();
     });
 
-    it('returns curated actor when found by ID', async () => {
+    it('returns curated actor when found', async () => {
         const bundle = {
             authData: {
                 access_token: TEST_USER_TOKEN,

--- a/test/searches/get_actor.js
+++ b/test/searches/get_actor.js
@@ -60,8 +60,17 @@ describe('search get actor details', () => {
             scope = nock('https://api.apify.com')
                 .get(`/v2/acts/${ACTOR_SAMPLE.id}`)
                 .reply(200, {
-                    // Extra fields (e.g. versions, userId) that must be dropped by the curation.
-                    data: { ...ACTOR_SAMPLE, userId: 'wRsJZtadYvn4mBZmm', versions: [{ versionNumber: '0.1' }] },
+                    data: {
+                        ...ACTOR_SAMPLE,
+                        // Top-level and nested noise that the curation must drop.
+                        userId: 'wRsJZtadYvn4mBZmm',
+                        versions: [{ versionNumber: '0.1' }],
+                        stats: { ...ACTOR_SAMPLE.stats, bookmarkCount: 1377, totalUsers7Days: 2 },
+                        defaultRunOptions: { ...ACTOR_SAMPLE.defaultRunOptions, restartOnError: true },
+                        taggedBuilds: {
+                            latest: { buildId: 'z2EryhbfhgSyqj6Hn', buildNumber: '0.0.2', finishedAt: '2019-06-10T11:15:49.286Z', buildNumberInt: 2 },
+                        },
+                    },
                 });
         }
 
@@ -71,9 +80,18 @@ describe('search get actor details', () => {
         expect(testResult[0].id).to.be.a('string');
         expect(testResult[0].name).to.be.a('string');
         expect(testResult[0].username).to.be.a('string');
-        // Non-curated fields must not leak through.
+        // Curation must strip API noise (asserted in both mocked and E2E modes: the real
+        // web-scraper response also carries stats.bookmarkCount and defaultRunOptions.restartOnError).
         expect(testResult[0].versions).to.be.eql(undefined);
         expect(testResult[0].userId).to.be.eql(undefined);
+        expect(testResult[0].stats.bookmarkCount).to.be.eql(undefined);
+        expect(testResult[0].defaultRunOptions.restartOnError).to.be.eql(undefined);
+        // Exact curated shape is asserted against the deterministic mock.
+        if (!TEST_USER_TOKEN) {
+            expect(testResult[0].stats).to.have.keys(['totalRuns', 'totalUsers', 'lastRunStartedAt']);
+            expect(testResult[0].defaultRunOptions).to.have.keys(['build', 'timeoutSecs', 'memoryMbytes']);
+            expect(testResult[0].taggedBuilds.latest).to.have.keys(['buildId', 'buildNumber']);
+        }
 
         scope?.done();
     });


### PR DESCRIPTION
## What & why

Part of #121 (Zapier Agents compatibility). Adds a **Get Actor Details** search so agents can inspect an Actor (title, description, public status, permission level, run options) before running it, completing the chain **Search Store → Get Actor Details → Run Actor**.

## Changes

- **`src/searches/get_actor.js`**: `GET /v2/acts/{actorId}` via `wrapRequestWithRetries`; 404 → `[]`, else returns `[actor]`. Accepts an Actor ID or `username/name` slug (slug's `/` normalized to `~`, plain IDs unchanged).
- **Curation**: deep `_.pick` trims nested objects to the useful sub-fields (`stats` keeps runs/users/lastRun; `defaultRunOptions` keeps build/timeout/memory); `taggedBuilds` kept but each build trimmed to `buildId` + `buildNumber`. Internal fields (`userId`, `versions`, ...) dropped.
- **`src/consts.js`**: `ACTOR_SAMPLE` + `ACTOR_OUTPUT_FIELDS`.
- **`index.js`**: registered.
- **`test/searches/get_actor.js`**: found (curated fields present, noise stripped), slug → `~` normalization, 404 → `[]`.

### Action metadata

| Field | Value |
| -- | -- |
| key / noun / label | `getActorDetails` / Actor / Get Actor Details |
| description | Retrieves metadata and description for a specific Actor, including its title, description, and whether it is publicly available. Use this to confirm an actor is suitable before running it. |

**Input:** `actorId` (required). Free-text by design (no dropdown, so any public Store Actor resolves; source of the advisory `D004` warning).
**Outputs:** `id`, `name`, `title`, `description`, `username`, `isPublic`, `actorPermissionLevel`, `createdAt`, `modifiedAt`, `standbyUrl`, `stats__{totalRuns,totalUsers,lastRunStartedAt}`, `defaultRunOptions__{build,timeoutSecs,memoryMbytes}`, plus `taggedBuilds` per tag.

## Testing

Mocked `63 passing / 0 failing` (+3). Lint clean (bar pre-existing `no-console`), `validate` sound. Live via `zapier-platform invoke` and in the Zapier editor (private v4.5.12): both slug forms return the curated `[actor]`, missing Actor → `[]`.

## Notes

- **Field-name corrections vs. ticket** (per docs.apify.com/api/v2): `stats.runCount` doesn't exist (used `stats.totalRuns`); permission field is `actorPermissionLevel` (`LIMITED_PERMISSIONS`/`FULL_PERMISSIONS`), not `permissionLevel`. `actorPermissionLevel` included beyond spec as a hook for the approval flow (backlog #8).
- **Release**: a push from this branch shows a `C011` warning that `getActorRunById` (#122, separate branch) is missing. Expected. Release from the epic umbrella branch after both merge, not this branch alone.
- No renamed keys, no auth changes, no version/CHANGELOG edits.