### PR TITLE
feat: 128 zapier new search search apify store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.5.9 / 2026-07-23
+## What's Changed
+* fix: vulnerabilities by @protoss70
+* fix: form-data vulnerability fix by @JanHranicky
+
+
+**Full Changelog**: https://github.com/apify/apify-zapier-integration/compare/v4.5.8...v4.5.9
+
 ## 4.5.8 / 2026-05-11
 - timeout bug
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 4.5.9 / 2026-07-23
-## What's Changed
-* fix: vulnerabilities by @protoss70
-* fix: form-data vulnerability fix by @JanHranicky
-
-
-**Full Changelog**: https://github.com/apify/apify-zapier-integration/compare/v4.5.8...v4.5.9
-
 ## 4.5.8 / 2026-05-11
 - timeout bug
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const taskLastRunSearch = require('./src/searches/task_last_run');
 const actorLastRunSearch = require('./src/searches/actor_last_run');
 const getValueSearch = require('./src/searches/get_value');
 const fetchItemsSearch = require('./src/searches/fetch_items');
+const searchStoreSearch = require('./src/searches/search_store');
 
 /**
  * Apify APP definition
@@ -61,6 +62,7 @@ const App = {
         [actorLastRunSearch.key]: actorLastRunSearch,
         [getValueSearch.perform.key]: getValueSearch.perform,
         [fetchItemsSearch.key]: fetchItemsSearch,
+        [searchStoreSearch.key]: searchStoreSearch,
     },
 
     // If you want your creates to show up, you better include it here!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,16 +1872,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2239,9 +2239,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4894,22 +4894,6 @@
       },
       "optionalDependencies": {
         "@types/node": "^20.3.1"
-      }
-    },
-    "node_modules/zapier-platform-core/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/zapier-platform-core/node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.5.8",
+  "version": "4.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apify-zapier-integration",
-      "version": "4.5.8",
+      "version": "4.5.9",
       "dependencies": {
         "@apify/consts": "^2.40.0",
         "@apify/utilities": "^2.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.5.8",
+  "version": "4.5.9",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-zapier-integration",
-  "version": "4.5.9",
+  "version": "4.5.8",
   "description": "Apify integration for Zapier platform",
   "homepage": "https://apify.com/",
   "author": "Jakub Drobník <jakub.drobnik@apify.com>",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "axios": "^1.17.0",
     "diff": "^8.0.3",
     "flatted": "^3.4.2",
+    "form-data": "^4.0.6",
     "lodash": "$lodash",
     "picomatch": "^2.3.2",
     "serialize-javascript": "^7.0.5"

--- a/src/consts.js
+++ b/src/consts.js
@@ -277,7 +277,7 @@ const DEFAULT_PAGINATION_LIMIT = 500;
 const LEGACY_PHANTOM_JS_CRAWLER_ID = 'YPh5JENjSSR6vBf2E';
 
 // Field to omit from actor run, these are useless in Zapier
-const OMIT_ACTOR_RUN_FIELDS = ['meta', 'stats', 'options', 'userId', 'output'];
+const OMIT_ACTOR_RUN_FIELDS = ['meta', 'stats', 'options', 'userId', 'output', 'standby'];
 
 // Field to pick from dataset detail
 const DATASET_PUBLISH_FIELDS = ['id', 'name', 'createdAt', 'modifiedAt', 'itemCount', 'cleanItemCount', 'actId', 'actRunId'];

--- a/src/consts.js
+++ b/src/consts.js
@@ -220,6 +220,35 @@ const TASK_RUN_SAMPLE = {
 
 const TASK_RUN_OUTPUT_FIELDS = ACTOR_RUN_OUTPUT_FIELDS.concat([{ key: 'actorTaskId', label: 'Actor task ID', type: 'string' }]);
 
+// Single Apify Store item, curated to the fields an agent needs to pick and chain an Actor.
+// The `stats.*` popularity/recency signals are flattened to `stats__*` keys (matching the
+// dynamic-field convention used elsewhere) so Zapier renders them as flat output fields.
+const STORE_ACTOR_SAMPLE = {
+    id: 'zdc3Pyhyz3m8vjDeM',
+    name: 'web-scraper',
+    title: 'Web Scraper',
+    description: 'Crawls arbitrary websites using a browser and extracts structured data from web pages.',
+    username: 'apify',
+    url: 'https://apify.com/apify/web-scraper',
+    categories: ['DEVELOPER_TOOLS', 'AUTOMATION'],
+    stats__totalRuns: 3208782,
+    stats__totalUsers: 62598,
+    stats__lastRunStartedAt: '2026-07-10T09:41:39.937Z',
+};
+
+const STORE_ACTOR_OUTPUT_FIELDS = [
+    { key: 'id', label: 'ID', type: 'string' },
+    { key: 'name', label: 'Name', type: 'string' },
+    { key: 'title', label: 'Title', type: 'string' },
+    { key: 'description', label: 'Description', type: 'string' },
+    { key: 'username', label: 'Username', type: 'string' },
+    { key: 'url', label: 'Store URL', type: 'string' },
+    { key: 'categories', label: 'Categories', type: 'string', list: true },
+    { key: 'stats__totalRuns', label: 'Total runs', type: 'number' },
+    { key: 'stats__totalUsers', label: 'Total users', type: 'number' },
+    { key: 'stats__lastRunStartedAt', label: 'Last run started at' },
+];
+
 const DATASET_SAMPLE = {
     id: 'fYYRaBM5FSoCZ2Tf9',
     name: 'dataset-sample',
@@ -334,6 +363,8 @@ module.exports = {
     ACTOR_RUN_OUTPUT_FIELDS,
     TASK_RUN_SAMPLE,
     TASK_RUN_OUTPUT_FIELDS,
+    STORE_ACTOR_SAMPLE,
+    STORE_ACTOR_OUTPUT_FIELDS,
     DEFAULT_KEY_VALUE_STORE_KEYS,
     DEFAULT_PAGINATION_LIMIT,
     LEGACY_PHANTOM_JS_CRAWLER_ID,

--- a/src/searches/search_store.js
+++ b/src/searches/search_store.js
@@ -22,7 +22,7 @@ const CURATED_STORE_ACTOR_FIELDS = [
 
 /**
  * Curates a single Apify Store item down to the fields an agent needs to select
- * an Actor and chain it into Run Actor / Get Actor Details.
+ * an Actor and chain it into Run Actor.
  */
 const curateStoreActor = (item) => {
     const actor = _.pick(item, CURATED_STORE_ACTOR_FIELDS);

--- a/src/searches/search_store.js
+++ b/src/searches/search_store.js
@@ -1,0 +1,100 @@
+const _ = require('lodash');
+const {
+    STORE_ACTOR_SAMPLE,
+    STORE_ACTOR_OUTPUT_FIELDS,
+    APIFY_API_ENDPOINTS,
+} = require('../consts');
+const { wrapRequestWithRetries } = require('../request_helpers');
+
+const DEFAULT_STORE_SEARCH_LIMIT = 10;
+
+// Top-level fields kept from each store item. `stats` popularity/recency signals are
+// flattened separately below into `stats__*` keys, so `stats` itself is not picked.
+const CURATED_STORE_ACTOR_FIELDS = [
+    'id',
+    'name',
+    'title',
+    'description',
+    'username',
+    'url',
+    'categories',
+];
+
+/**
+ * Curates a single Apify Store item down to the fields an agent needs to select
+ * an Actor and chain it into Run Actor / Get Actor Details.
+ */
+const curateStoreActor = (item) => {
+    const actor = _.pick(item, CURATED_STORE_ACTOR_FIELDS);
+    const stats = item.stats || {};
+
+    return {
+        ...actor,
+        stats__totalRuns: stats.totalRuns,
+        stats__totalUsers: stats.totalUsers,
+        stats__lastRunStartedAt: stats.lastRunStartedAt,
+    };
+};
+
+const searchApifyStore = async (z, bundle) => {
+    const { query, offset } = bundle.inputData;
+    const limit = bundle.inputData.limit || DEFAULT_STORE_SEARCH_LIMIT;
+
+    const params = { search: query, limit };
+    // Only send `offset` when provided, otherwise it serializes as an empty `offset=` query param.
+    if (offset !== undefined && offset !== null && offset !== '') params.offset = offset;
+
+    const response = await wrapRequestWithRetries(z.request, {
+        url: APIFY_API_ENDPOINTS.store,
+        params,
+    });
+
+    // After the `parseDataApiObject` middleware the store payload is `{ total, count, ..., items }`.
+    const items = response.data.items || [];
+    return items.map(curateStoreActor);
+};
+
+module.exports = {
+    key: 'searchApifyStore',
+    noun: 'Actor',
+    display: {
+        label: 'Search Apify Store',
+        description: 'Searches the public Apify Store for Actors matching a keyword or use case '
+            + '(e.g. "linkedin scraper", "google maps", "instagram"). Returns matching actors with their IDs, '
+            + 'which can be passed directly to the Run Actor action.',
+    },
+
+    operation: {
+        inputFields: [
+            {
+                label: 'Search query',
+                key: 'query',
+                required: true,
+                type: 'string',
+                helpText: 'Keyword or use-case description to search the Apify Store for, e.g. `linkedin scraper`.',
+            },
+            {
+                label: 'Limit',
+                key: 'limit',
+                required: false,
+                type: 'integer',
+                // Zapier field defaults must be strings, even for integer fields.
+                default: String(DEFAULT_STORE_SEARCH_LIMIT),
+                helpText: 'Maximum number of Actors to return. Keep this small (the default is 10) — '
+                    + 'a short, most-relevant list is easier for an agent to pick from than hundreds of results.',
+            },
+            {
+                label: 'Offset',
+                key: 'offset',
+                required: false,
+                type: 'integer',
+                helpText: 'Number of Actors to skip from the start of the results, e.g. `10` to fetch the next page.',
+            },
+        ],
+
+        perform: searchApifyStore,
+
+        sample: STORE_ACTOR_SAMPLE,
+        outputFields: STORE_ACTOR_OUTPUT_FIELDS,
+    },
+};

--- a/test/searches/search_store.js
+++ b/test/searches/search_store.js
@@ -1,0 +1,177 @@
+/* eslint-env mocha */
+const zapier = require('zapier-platform-core');
+const { expect } = require('chai');
+const nock = require('nock');
+const { TEST_USER_TOKEN } = require('../helpers');
+
+const App = require('../../index');
+
+const appTester = zapier.createAppTester(App);
+
+// A realistic pair of store items, including nested `stats` and extra fields that curation must drop.
+const STORE_ITEMS = [
+    {
+        id: 'LpVuK3Zozwuipa5bp',
+        name: 'linkedin-profile-scraper',
+        title: 'LinkedIn Profile Scraper',
+        description: 'Extract detailed information from LinkedIn profiles in bulk.',
+        username: 'harvestapi',
+        url: 'https://apify.com/harvestapi/linkedin-profile-scraper',
+        categories: ['LEAD_GENERATION', 'SOCIAL_MEDIA'],
+        stats: {
+            totalBuilds: 126,
+            totalRuns: 16075561,
+            totalUsers: 48054,
+            lastRunStartedAt: '2026-07-10T09:41:39.937Z',
+        },
+        // Non-curated fields that must not leak through.
+        pictureUrl: 'https://example.com/pic.webp',
+        currentPricingInfo: { pricingModel: 'PAY_PER_EVENT' },
+    },
+    {
+        id: 'dev0FusionActorId',
+        name: 'Linkedin-Profile-Scraper',
+        title: 'Mass Linkedin Profile Scraper',
+        description: 'Scrape LinkedIn profiles at scale.',
+        username: 'dev_fusion',
+        url: 'https://apify.com/dev_fusion/Linkedin-Profile-Scraper',
+        categories: ['LEAD_GENERATION'],
+        stats: {
+            totalBuilds: 130,
+            totalRuns: 22069898,
+            totalUsers: 61620,
+            lastRunStartedAt: '2026-07-10T09:38:39.019Z',
+        },
+    },
+];
+
+describe('search apify store', () => {
+    afterEach(async () => {
+        if (!TEST_USER_TOKEN) {
+            nock.cleanAll();
+        }
+    });
+
+    it('returns a curated array of actors when results are found', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                query: 'linkedin scraper',
+                limit: 2,
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/store')
+                .query({ search: 'linkedin scraper', limit: 2 })
+                .reply(200, {
+                    data: {
+                        total: 4624,
+                        count: 2,
+                        offset: 0,
+                        limit: 2,
+                        items: STORE_ITEMS,
+                    },
+                });
+        }
+
+        const testResult = await appTester(App.searches.searchApifyStore.operation.perform, bundle);
+
+        expect(testResult).to.be.an('array');
+        expect(testResult.length).to.be.at.least(1);
+
+        const [actor] = testResult;
+        expect(actor.id).to.be.a('string');
+        expect(actor.name).to.be.a('string');
+        expect(actor.username).to.be.a('string');
+        // runCount maps to stats.totalRuns, flattened to stats__totalRuns.
+        expect(actor.stats__totalRuns).to.be.a('number');
+        // Non-curated fields must not leak through.
+        expect(actor.pictureUrl).to.be.eql(undefined);
+        expect(actor.currentPricingInfo).to.be.eql(undefined);
+        expect(actor.stats).to.be.eql(undefined);
+
+        if (!TEST_USER_TOKEN) {
+            expect(testResult.length).to.be.eql(2);
+            expect(actor.stats__totalRuns).to.be.eql(16075561);
+            expect(actor.stats__totalUsers).to.be.eql(48054);
+        }
+
+        scope?.done();
+    });
+
+    it('sends search, limit and offset as query params', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                query: 'google maps',
+                limit: 5,
+                offset: 10,
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            // A satisfied scope with this exact query proves the params were sent correctly.
+            scope = nock('https://api.apify.com')
+                .get('/v2/store')
+                .query({ search: 'google maps', limit: 5, offset: 10 })
+                .reply(200, {
+                    data: {
+                        total: 0,
+                        count: 0,
+                        offset: 10,
+                        limit: 5,
+                        items: [],
+                    },
+                });
+        }
+
+        const testResult = await appTester(App.searches.searchApifyStore.operation.perform, bundle);
+
+        expect(testResult).to.be.an('array');
+
+        scope?.done();
+    });
+
+    it('returns an empty array when no actors match', async () => {
+        const bundle = {
+            authData: {
+                access_token: TEST_USER_TOKEN,
+            },
+            inputData: {
+                query: 'zzzznomatchqwerty12345',
+                limit: 5,
+            },
+        };
+
+        let scope;
+        if (!TEST_USER_TOKEN) {
+            scope = nock('https://api.apify.com')
+                .get('/v2/store')
+                .query({ search: 'zzzznomatchqwerty12345', limit: 5 })
+                .reply(200, {
+                    data: {
+                        total: 0,
+                        count: 0,
+                        offset: 0,
+                        limit: 5,
+                        items: [],
+                    },
+                });
+        }
+
+        const testResult = await appTester(App.searches.searchApifyStore.operation.perform, bundle);
+
+        expect(testResult).to.be.an('array');
+        expect(testResult.length).to.be.eql(0);
+
+        scope?.done();
+    });
+});

--- a/test/searches/search_store.js
+++ b/test/searches/search_store.js
@@ -88,7 +88,6 @@ describe('search apify store', () => {
         expect(actor.id).to.be.a('string');
         expect(actor.name).to.be.a('string');
         expect(actor.username).to.be.a('string');
-        // runCount maps to stats.totalRuns, flattened to stats__totalRuns.
         expect(actor.stats__totalRuns).to.be.a('number');
         // Non-curated fields must not leak through.
         expect(actor.pictureUrl).to.be.eql(undefined);


### PR DESCRIPTION
<html><head></head><body><hr>
<h2>What &amp; why</h2>
<p>Part of #121 (Zapier Agents compatibility). Adds a <strong>Search Apify Store</strong> action so agents can discover public Actors by keyword, completing the chain <strong>Search Store → Get Actor Details → Run Actor</strong> with no hardcoded IDs.</p>
<blockquote>
<p>Verified locally: mocked suite green, live API tested via <code>zapier-platform invoke</code>. <strong>Not yet tested in Zapier UI</strong> - blocked on <code>push</code> access (collaborator to admin request pending).</p>
</blockquote>
<h2>Changes</h2>
<ul>
<li><strong><code>src/searches/search_store.js</code></strong> - <code>GET /v2/store</code> via <code>wrapRequestWithRetries</code>; maps <code>response.data.items</code> through a <code>curateStoreActor</code> helper (<code>_.pick</code> + <code>stats.*</code> to <code>stats__*</code> flattening). No error catch: <code>/v2/store</code> returns <code>items: []</code> on no match, so any error is genuine. Defensive <code>offset</code> handling (Zapier sends <code>''</code> for unfilled optional ints).</li>
<li><strong><code>src/consts.js</code></strong> - new <code>STORE_ACTOR_SAMPLE</code> + <code>STORE_ACTOR_OUTPUT_FIELDS</code> with pre-flattened <code>stats__*</code> keys.</li>
<li><strong><code>index.js</code></strong> - registered.</li>
<li><strong><code>test/searches/search_store.js</code></strong> - 3 tests: curated fields present (incl. <code>stats__totalRuns</code>), non-curated stripped (<code>pictureUrl</code>/<code>currentPricingInfo</code>/raw <code>stats</code>), query params reach API, empty to <code>[]</code>.</li>
</ul>
<h3>Action metadata</h3>

Field | Value
-- | --
key | searchApifyStore
noun / label | Actor / Search Apify Store
description | Searches the public Apify Store for Actors matching a keyword or use case. Returns matching actors with IDs passable directly to Run Actor.


<p><strong>Inputs:</strong> <code>query</code> (required), <code>limit</code> (optional int, default 10, kept small for LLM context), <code>offset</code> (optional int).
<strong>Outputs:</strong> <code>id</code>, <code>name</code>, <code>title</code>, <code>description</code>, <code>username</code>, <code>url</code>, <code>categories</code>, <code>stats__totalRuns</code>, <code>stats__totalUsers</code>, <code>stats__lastRunStartedAt</code>.</p>
<h2>Testing</h2>
<ul>
<li>Mocked: <code>63 passing / 8 pending / 0 failing</code> (+3 new). Lint clean. <code>validate --without-style</code> sound.</li>
<li>Live: <code>zapier-platform invoke</code> returns correct array with populated <code>stats__totalRuns</code> (16M/22M/2.8M), confirming mapping.</li>
<li>Pre-existing E2E failures (shape drift, token-scope) unrelated.</li>
</ul>
<h2>Notes</h2>
<ul>
<li><strong>Field-name correction vs. ticket</strong> (verified live, consistent with #127): spec's <code>runCount</code> doesn't exist; real field is <code>stats.totalRuns</code>.</li>
<li><strong>Extra signals beyond spec:</strong> <code>stats__totalUsers</code>, <code>stats__lastRunStartedAt</code>, <code>url</code>, <code>categories</code>. Free in the response, stronger agent selection signal (per #127 review).</li>
<li><code>stats__lastRunStartedAt</code> intentionally untyped (matches all static date fields in <code>consts.js</code> and #127).</li>
<li>No renamed keys, no auth changes, no version/CHANGELOG edits. Targets epic branch, not <code>master</code>.</li>
</ul></body></html>