### PR TITLE
fix!: throw on empty items

### DIFF
--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -268,7 +268,7 @@ const findStorageOrThrow = async (z, storageIdOrName, { apiUrl, consoleUrl, labe
         if (!isNotFoundError(err)) throw err;
 
         const notFoundUrl = looksLikeApifyId(storageIdOrName) ? `${consoleUrl}/${storageIdOrName}` : consoleUrl;
-        throw new Error(
+        throw new z.errors.Error(
             `${label} "${storageIdOrName}" does not exist or your Apify account cannot access it. `
             + `Check the ${label.toLowerCase()} name or ID in Apify Console: ${notFoundUrl}`,
         );
@@ -293,7 +293,7 @@ const getOrCreateKeyValueStore = async (z, storeIdOrName) => {
         if (!isNotFoundError(err)) throw err;
         // ID-shaped input can't be a name to create, so a not-found ID is a real miss; names fall through to create below.
         if (looksLikeApifyId(storeIdOrName)) {
-            throw new Error(
+            throw new z.errors.Error(
                 `Key-value store "${storeIdOrName}" does not exist or your Apify account cannot access it. `
                 + 'Check the key-value store ID in Apify Console: '
                 + `https://console.apify.com/storage/key-value-stores/${storeIdOrName}`,

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { BUILD_TAG_LATEST, ACTOR_JOB_TERMINAL_STATUSES } = require('@apify/consts');
+const { BUILD_TAG_LATEST, ACTOR_JOB_TERMINAL_STATUSES, APIFY_ID_REGEX } = require('@apify/consts');
 const { ApifyClient } = require('apify-client');
 const { APIFY_API_ENDPOINTS, DEFAULT_KEY_VALUE_STORE_KEYS, LEGACY_PHANTOM_JS_CRAWLER_ID,
     OMIT_ACTOR_RUN_FIELDS, FETCH_DATASET_ITEMS_ITEMS_LIMIT, DATASET_ITEMS_INLINE_MAX_BYTES,
@@ -11,6 +11,9 @@ const { wrapRequestWithRetries, isNotFoundError } = require('./request_helpers')
 
 // Key of field to use internally to compute changes in fields.
 const ACTOR_ID_REFERENCE_FIELD_KEY = 'referenceActorId';
+
+// A full-string Apify resource ID; anything else is treated as a resource name.
+const looksLikeApifyId = (value) => new RegExp(`^${APIFY_ID_REGEX.source}$`).test(value);
 
 const getDatasetPublicUrl = async (token, datasetIdOrName) => {
     const apifyClient = new ApifyClient({ token });
@@ -244,7 +247,7 @@ const getActorRun = async (z, bundle) => {
 };
 
 /**
- * Get store by ID or by name
+ * Get store by ID or by name. A name that does not exist is created, an ID that does not exist throws.
  * @param z
  * @param storeIdOrName - Key-value store ID or name
  */
@@ -259,6 +262,14 @@ const getOrCreateKeyValueStore = async (z, storeIdOrName) => {
         store = storeResponse.data;
     } catch (err) {
         if (!isNotFoundError(err)) throw err;
+        // ID-shaped input can't be a name to create, so a not-found ID is a real miss; names fall through to create below.
+        if (looksLikeApifyId(storeIdOrName)) {
+            throw new Error(
+                `Key-value store "${storeIdOrName}" does not exist or your Apify account cannot access it. `
+                + 'Check the key-value store ID in Apify Console: '
+                + `https://console.apify.com/storage/key-value-stores/${storeIdOrName}`,
+            );
+        }
     }
 
     // The second creates store with name, in case storeId not found.
@@ -703,6 +714,7 @@ module.exports = {
     getActorRun,
     getOrCreateKeyValueStore,
     getDatasetItems,
+    looksLikeApifyId,
     getActorAdditionalFields,
     getPrefilledValuesFromInputSchema,
     createFieldsFromInputSchemaV1,

--- a/src/apify_helpers.js
+++ b/src/apify_helpers.js
@@ -246,6 +246,35 @@ const getActorRun = async (z, bundle) => {
     return [enrichedRun];
 };
 
+// The API resolves an ID or `username~name`, the `~name` shorthand means a name in the token owner's account.
+const toStorageLookupId = (idOrName) => (
+    looksLikeApifyId(idOrName) || idOrName.includes('~') ? idOrName : `~${idOrName}`
+);
+
+/**
+ * Get a dataset or a key-value store by ID or by name, a storage that does not exist throws.
+ * @param z
+ * @param storageIdOrName - Storage ID or name
+ * @param options - API and Apify Console URLs of the storage type, and its label used in the error message
+ */
+const findStorageOrThrow = async (z, storageIdOrName, { apiUrl, consoleUrl, label }) => {
+    try {
+        const storageResponse = await wrapRequestWithRetries(z.request, {
+            url: `${apiUrl}/${toStorageLookupId(storageIdOrName)}`,
+            method: 'GET',
+        });
+        return storageResponse.data;
+    } catch (err) {
+        if (!isNotFoundError(err)) throw err;
+
+        const notFoundUrl = looksLikeApifyId(storageIdOrName) ? `${consoleUrl}/${storageIdOrName}` : consoleUrl;
+        throw new Error(
+            `${label} "${storageIdOrName}" does not exist or your Apify account cannot access it. `
+            + `Check the ${label.toLowerCase()} name or ID in Apify Console: ${notFoundUrl}`,
+        );
+    }
+};
+
 /**
  * Get store by ID or by name. A name that does not exist is created, an ID that does not exist throws.
  * @param z
@@ -713,8 +742,8 @@ module.exports = {
     unsubscribeWebhook,
     getActorRun,
     getOrCreateKeyValueStore,
+    findStorageOrThrow,
     getDatasetItems,
-    looksLikeApifyId,
     getActorAdditionalFields,
     getPrefilledValuesFromInputSchema,
     createFieldsFromInputSchemaV1,

--- a/src/creates/set_value.js
+++ b/src/creates/set_value.js
@@ -39,9 +39,8 @@ module.exports = {
         inputFields: [
             {
                 label: 'Key-value store',
-                // TODO: We need to make sure if user enters ID, we don't create a named store with that ID.
-                // That can be checked with regex
-                helpText: 'Please enter name or ID of the key-value store. If the store with the name doesn\'t exist, it will be created.',
+                helpText: 'Please enter the name or ID of the key-value store. If a store with the given name doesn\'t exist, '
+                    + 'it will be created. An ID that doesn\'t exist will fail.',
                 key: 'storeIdOrName',
                 required: true,
             },

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -1,13 +1,9 @@
 const _ = require('lodash');
-const { APIFY_ID_REGEX } = require('@apify/consts');
 const { APIFY_API_ENDPOINTS, DATASET_PUBLISH_FIELDS,
     DATASET_OUTPUT_FIELDS, DATASET_SAMPLE } = require('../consts');
 const { wrapRequestWithRetries } = require('../request_helpers');
-const { getDatasetItems } = require('../apify_helpers');
+const { getDatasetItems, looksLikeApifyId } = require('../apify_helpers');
 const { getDatasetItemsOutputFields } = require('../output_fields');
-
-// A full-string Apify resource ID; anything else is treated as a dataset name.
-const looksLikeApifyId = (value) => new RegExp(`^${APIFY_ID_REGEX.source}$`).test(value);
 
 const findDatasetByNameOrId = async (z, datasetIdOrName) => {
     // The first try to get dataset by ID.

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -1,43 +1,18 @@
 const _ = require('lodash');
 const { APIFY_API_ENDPOINTS, DATASET_PUBLISH_FIELDS,
     DATASET_OUTPUT_FIELDS, DATASET_SAMPLE } = require('../consts');
-const { wrapRequestWithRetries } = require('../request_helpers');
-const { getDatasetItems, looksLikeApifyId } = require('../apify_helpers');
+const { getDatasetItems, findStorageOrThrow } = require('../apify_helpers');
 const { getDatasetItemsOutputFields } = require('../output_fields');
 
-const findDatasetByNameOrId = async (z, datasetIdOrName) => {
-    // The first try to get dataset by ID.
-    try {
-        const datasetResponse = await wrapRequestWithRetries(z.request, {
-            url: `${APIFY_API_ENDPOINTS.datasets}/${datasetIdOrName}`,
-            method: 'GET',
-        });
-        return datasetResponse.data;
-    } catch (err) {
-        if (!err.message.includes('not found')) throw err;
-        // ID-shaped input can't be a name to create, so a not-found ID is a real miss; names fall through to create below.
-        if (looksLikeApifyId(datasetIdOrName)) {
-            throw new Error(
-                `Dataset "${datasetIdOrName}" does not exist or your Apify account cannot access it. `
-                + 'Check the dataset ID in Apify Console: '
-                + `https://console.apify.com/storage/datasets/${datasetIdOrName}`,
-            );
-        }
-    }
-    // The second creates dataset with name, in case datasetId not found.
-    const storeResponse = await wrapRequestWithRetries(z.request, {
-        url: `${APIFY_API_ENDPOINTS.datasets}`,
-        method: 'POST',
-        params: {
-            name: datasetIdOrName,
-        },
-    });
-    return storeResponse.data;
+const DATASET_LOOKUP = {
+    apiUrl: APIFY_API_ENDPOINTS.datasets,
+    consoleUrl: 'https://console.apify.com/storage/datasets',
+    label: 'Dataset',
 };
 
 const getItems = async (z, bundle) => {
     const { datasetIdOrName, limit, offset, fields, omit } = bundle.inputData;
-    const dataset = await findDatasetByNameOrId(z, datasetIdOrName);
+    const dataset = await findStorageOrThrow(z, datasetIdOrName, DATASET_LOOKUP);
 
     // NOTE: Because testing user had _id instead of id in data and we run integration tests under this user.
     dataset.id = dataset.id || dataset._id;
@@ -69,7 +44,7 @@ const getItems = async (z, bundle) => {
 
 const getAdditionalDatasetItemsOutputFields = async (z, bundle) => {
     const { datasetIdOrName } = bundle.inputData;
-    const dataset = await findDatasetByNameOrId(z, datasetIdOrName);
+    const dataset = await findStorageOrThrow(z, datasetIdOrName, DATASET_LOOKUP);
 
     return getDatasetItemsOutputFields(z, dataset.id, dataset.actId, bundle.authData.access_token, 'items[]');
 };

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -26,7 +26,7 @@ const getItems = async (z, bundle) => {
     const datasetItems = await getDatasetItems(z, dataset.id, bundle.authData.access_token, params, dataset.actId);
 
     if (!datasetItems.items || datasetItems.items.length === 0) {
-        throw new Error(
+        throw new z.errors.Error(
             `Dataset "${datasetIdOrName}" has no items${offset ? ` from offset ${offset}` : ''}. `
             + 'Check that the dataset name or ID is correct, or view its contents in Apify Console: '
             + `https://console.apify.com/storage/datasets/${dataset.id}`,

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -53,8 +53,7 @@ const getItems = async (z, bundle) => {
     if (!datasetItems.items || datasetItems.items.length === 0) {
         throw new Error(
             `Dataset "${datasetIdOrName}" has no items${offset ? ` from offset ${offset}` : ''}. `
-            + 'Check that the Actor or task run finished successfully and produced results, '
-            + 'and that the dataset name or ID is correct: '
+            + 'Check that the dataset name or ID is correct, or view its contents in Apify Console: '
             + `https://console.apify.com/storage/datasets/${dataset.id}`,
         );
     }

--- a/src/searches/fetch_items.js
+++ b/src/searches/fetch_items.js
@@ -54,6 +54,15 @@ const getItems = async (z, bundle) => {
 
     const datasetItems = await getDatasetItems(z, dataset.id, bundle.authData.access_token, params, dataset.actId);
 
+    if (!datasetItems.items || datasetItems.items.length === 0) {
+        throw new Error(
+            `Dataset "${datasetIdOrName}" has no items${offset ? ` from offset ${offset}` : ''}. `
+            + 'Check that the Actor or task run finished successfully and produced results, '
+            + 'and that the dataset name or ID is correct: '
+            + `https://console.apify.com/storage/datasets/${dataset.id}`,
+        );
+    }
+
     // Pick some fields to Zapier UI, other fields are useless for Zapier users.
     const cleanDataset = _.pick(dataset, DATASET_PUBLISH_FIELDS);
 

--- a/src/searches/get_value.js
+++ b/src/searches/get_value.js
@@ -34,7 +34,7 @@ const getValue = async (z, bundle) => {
 
     if (sizeRequest.status === 404) {
         throw new z.errors.Error(
-            `No record found for key "${key}" in key-value store ${store.id}. `
+            `No record found for key "${key}" in key-value store "${store.id}". `
             + 'The store exists but has no record under that key. Check the key name, '
             + 'or list the store keys in Apify Console: '
             + `https://console.apify.com/storage/key-value-stores/${store.id}`,

--- a/src/searches/get_value.js
+++ b/src/searches/get_value.js
@@ -1,6 +1,12 @@
 const { APIFY_API_ENDPOINTS } = require('../consts');
-const { getOrCreateKeyValueStore } = require('../apify_helpers');
+const { findStorageOrThrow } = require('../apify_helpers');
 const { wrapRequestWithRetries } = require('../request_helpers');
+
+const KEY_VALUE_STORE_LOOKUP = {
+    apiUrl: APIFY_API_ENDPOINTS.keyValueStores,
+    consoleUrl: 'https://console.apify.com/storage/key-value-stores',
+    label: 'Key-value store',
+};
 
 const stashFunction = async (z, bundle) => {
     const { contentType, storeId, key } = bundle.inputData;
@@ -25,7 +31,7 @@ const stashFunction = async (z, bundle) => {
 
 const getValue = async (z, bundle) => {
     const { storeIdOrName, key } = bundle.inputData;
-    const store = await getOrCreateKeyValueStore(z, storeIdOrName);
+    const store = await findStorageOrThrow(z, storeIdOrName, KEY_VALUE_STORE_LOOKUP);
 
     const sizeRequest = await wrapRequestWithRetries(z.request, {
         url: `${APIFY_API_ENDPOINTS.keyValueStores}/${store.id}/records/${key}`,

--- a/test/creates/set_value.js
+++ b/test/creates/set_value.js
@@ -1,10 +1,14 @@
 /* eslint-env mocha */
 const zapier = require('zapier-platform-core');
-const { expect } = require('chai');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const nock = require('nock');
 const { TEST_USER_TOKEN, apifyClient, randomString, getMockKVStore} = require('../helpers');
 const { KEY_VALUE_STORE_SAMPLE } = require('../../src/consts');
 const App = require('../../index');
+
+const { expect } = chai;
+chai.use(chaiAsPromised);
 
 const appTester = zapier.createAppTester(App);
 
@@ -104,4 +108,27 @@ describe('set key-value store value', () => {
 
         scope?.done();
     }).timeout(10000);
+
+    it('throws when an ID-shaped store is not found instead of creating one', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const missingStoreId = 'aBcDeFgHiJkLmNoPq'; // 17-char, ID-shaped
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: {
+                storeIdOrName: missingStoreId,
+                key: randomString(),
+                value: JSON.stringify({ myKey: randomString() }),
+            },
+        };
+
+        // No POST is mocked, so scope.done() proves no store was created.
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/key-value-stores/${missingStoreId}`)
+            .reply(404, { error: { type: 'record-not-found', message: 'Key-value store was not found' } });
+
+        await expect(appTester(App.creates.keyValueStoreSetValue.operation.perform, bundle))
+            .to.be.rejectedWith(/does not exist/);
+        scope.done();
+    });
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -11,6 +11,13 @@ async function pageFunction({ request, setValue }) {
 
 const randomString = () => Math.random().toString(32).split('.')[1];
 
+// A 17-char alphanumeric string, i.e. shaped like a real Apify resource ID (APIFY_ID_REGEX).
+const randomApifyId = () => {
+    let id = '';
+    while (id.length < 17) id += randomString();
+    return id.slice(0, 17);
+};
+
 // Injects all secrets from .env file
 // There should be token for running local tests
 zapier.tools.env.inject();
@@ -443,6 +450,7 @@ const getMockInputSchema = () => ({
 module.exports = {
     TEST_USER_TOKEN,
     randomString,
+    randomApifyId,
     apifyClient,
     createWebScraperTask,
     createAndBuildActor,

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -157,7 +157,29 @@ describe('fetch dataset items', () => {
         scope.done();
     });
 
-    it('creates a dataset when a name (not an ID) is not found', async () => {
+    it('throws when the dataset has no items', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { datasetIdOrName: testDatasetId },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, { data: getMockDataset({ id: testDatasetId }) });
+        scope.get(`/v2/datasets/${testDatasetId}/items`)
+            .query(true)
+            .reply(200, []);
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, mockDatasetPublicUrl(testDatasetId));
+
+        await expect(appTester(App.searches.fetchDatasetItems.operation.perform, bundle))
+            .to.be.rejectedWith(/has no items/);
+        scope.done();
+    });
+
+    it('creates a dataset when a name (not an ID) is not found, then throws because it is empty', async () => {
         if (TEST_USER_TOKEN) return; // Only run with nock mocks
 
         const datasetName = 'my-zapier-dataset';
@@ -179,9 +201,8 @@ describe('fetch dataset items', () => {
         scope.get(`/v2/datasets/${createdId}`)
             .reply(200, mockDatasetPublicUrl(createdId));
 
-        const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
-
-        expect(testResult[0].items).to.eql([]);
+        await expect(appTester(App.searches.fetchDatasetItems.operation.perform, bundle))
+            .to.be.rejectedWith(/has no items/);
         scope.done();
     });
 });

--- a/test/searches/fetch_items.js
+++ b/test/searches/fetch_items.js
@@ -3,7 +3,7 @@ const zapier = require('zapier-platform-core');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const nock = require('nock');
-const { TEST_USER_TOKEN, apifyClient, randomString, getMockDataset, mockDatasetPublicUrl } = require('../helpers');
+const { TEST_USER_TOKEN, apifyClient, randomString, randomApifyId, getMockDataset, mockDatasetPublicUrl } = require('../helpers');
 const { DATASET_SAMPLE } = require('../../src/consts');
 
 const App = require('../../index');
@@ -14,11 +14,12 @@ const { expect } = chai;
 const appTester = zapier.createAppTester(App);
 
 describe('fetch dataset items', () => {
-    let testDatasetId = randomString();
+    let testDatasetId = randomApifyId();
+    const testDatasetName = `test-zapier-${randomString()}`;
 
     before(async () => {
         if (TEST_USER_TOKEN) {
-            const dataset = await apifyClient.datasets().getOrCreate(`test-zapier-${randomString()}`);
+            const dataset = await apifyClient.datasets().getOrCreate(testDatasetName);
             testDatasetId = dataset.id;
         }
     });
@@ -179,30 +180,78 @@ describe('fetch dataset items', () => {
         scope.done();
     });
 
-    it('creates a dataset when a name (not an ID) is not found, then throws because it is empty', async () => {
+    it('throws when a dataset name is not found instead of creating it', async () => {
         if (TEST_USER_TOKEN) return; // Only run with nock mocks
 
         const datasetName = 'my-zapier-dataset';
-        const createdId = randomString();
         const bundle = {
             authData: { access_token: TEST_USER_TOKEN },
             inputData: { datasetIdOrName: datasetName },
         };
 
         const scope = nock('https://api.apify.com');
-        scope.get(`/v2/datasets/${datasetName}`)
+        scope.get(`/v2/datasets/~${datasetName}`)
             .reply(404, { error: { type: 'record-not-found', message: 'Dataset was not found' } });
-        scope.post('/v2/datasets')
-            .query({ name: datasetName })
-            .reply(201, { data: getMockDataset({ id: createdId }) });
-        scope.get(`/v2/datasets/${createdId}/items`)
-            .query(true)
-            .reply(200, []);
-        scope.get(`/v2/datasets/${createdId}`)
-            .reply(200, mockDatasetPublicUrl(createdId));
 
         await expect(appTester(App.searches.fetchDatasetItems.operation.perform, bundle))
-            .to.be.rejectedWith(/has no items/);
+            .to.be.rejectedWith(/does not exist/);
         scope.done();
     });
+
+    it('resolves a bare dataset name in the token owner\'s account', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const datasetName = 'my-zapier-dataset';
+        const items = [{ name: 'test', url: 'https://example.com' }];
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { datasetIdOrName: datasetName },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/datasets/~${datasetName}`)
+            .reply(200, { data: getMockDataset({ id: testDatasetId, name: datasetName }) });
+        scope.get(`/v2/datasets/${testDatasetId}/items`)
+            .query(true)
+            .reply(200, items);
+        scope.get(`/v2/datasets/${testDatasetId}`)
+            .reply(200, mockDatasetPublicUrl(testDatasetId));
+
+        const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
+
+        expect(testResult[0].items).to.eql(items);
+        scope.done();
+    });
+
+    it('fetches items by dataset name against the real API', async () => {
+        if (!TEST_USER_TOKEN) return; // Only run as E2E test
+
+        await apifyClient.dataset(testDatasetId).pushItems([{ testKey: 'testValue' }]);
+
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { datasetIdOrName: testDatasetName },
+        };
+
+        const testResult = await appTester(App.searches.fetchDatasetItems.operation.perform, bundle);
+
+        expect(testResult[0].id).to.be.eql(testDatasetId);
+        expect(testResult[0].items.length).to.be.above(0);
+    }).timeout(120000);
+
+    it('throws for a dataset name that does not exist against the real API', async () => {
+        if (!TEST_USER_TOKEN) return; // Only run as E2E test
+
+        const missingName = `test-zapier-missing-${randomString()}`;
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { datasetIdOrName: missingName },
+        };
+
+        await expect(appTester(App.searches.fetchDatasetItems.operation.perform, bundle))
+            .to.be.rejectedWith(/does not exist/);
+
+        const { items: datasets } = await apifyClient.datasets().list({ desc: true, limit: 10 });
+        expect(datasets.some((dataset) => dataset.name === missingName)).to.be.eql(false);
+    }).timeout(120000);
 });

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const nock = require('nock');
 
-const { TEST_USER_TOKEN, apifyClient, randomString, getMockKVStore } = require('../helpers');
+const { TEST_USER_TOKEN, apifyClient, randomString, randomApifyId, getMockKVStore } = require('../helpers');
 const App = require('../../index');
 
 const { expect } = chai;
@@ -13,7 +13,7 @@ chai.use(chaiAsPromised);
 const appTester = zapier.createAppTester(App);
 
 describe('get key-value store value', () => {
-    let testStoreId = randomString();
+    let testStoreId = randomApifyId();
 
     before(async () => {
         if (TEST_USER_TOKEN) {
@@ -171,28 +171,49 @@ describe('get key-value store value', () => {
         scope.done();
     });
 
-    it('creates a store when a name (not an ID) is not found, then throws because the key is missing', async () => {
+    it('throws when a store name is not found instead of creating it', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const storeName = 'my-zapier-store';
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { storeIdOrName: storeName, key: randomString() },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/key-value-stores/~${storeName}`)
+            .reply(404, { error: { type: 'record-not-found', message: 'Key-value store was not found' } });
+
+        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle))
+            .to.be.rejectedWith(/does not exist/);
+        scope.done();
+    });
+
+    it('resolves a bare store name in the token owner\'s account', async () => {
         if (TEST_USER_TOKEN) return; // Only run with nock mocks
 
         const storeName = 'my-zapier-store';
         const storeKey = randomString();
-        const createdId = randomString();
+        const storeValue = { key: 'value' };
         const bundle = {
             authData: { access_token: TEST_USER_TOKEN },
             inputData: { storeIdOrName: storeName, key: storeKey },
         };
 
         const scope = nock('https://api.apify.com');
-        scope.get(`/v2/key-value-stores/${storeName}`)
-            .reply(404, { error: { type: 'record-not-found', message: 'Key-value store was not found' } });
-        scope.post('/v2/key-value-stores')
-            .query({ name: storeName })
-            .reply(201, { data: getMockKVStore({ id: createdId }) });
-        scope.head(`/v2/key-value-stores/${createdId}/records/${storeKey}`)
-            .reply(404);
+        scope.get(`/v2/key-value-stores/~${storeName}`)
+            .reply(200, { data: getMockKVStore({ id: testStoreId, name: storeName }) });
+        scope.head(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
+            .reply(200, undefined, {
+                'content-type': 'application/json',
+                'content-length': Buffer.byteLength(JSON.stringify(storeValue)),
+            });
+        scope.get(`/v2/key-value-stores/${testStoreId}/records/${storeKey}`)
+            .reply(200, storeValue);
 
-        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle))
-            .to.be.rejectedWith(/No record found for key/);
+        const testResult = await appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle);
+
+        expect(storeValue).to.be.eql(testResult[0]);
         scope.done();
     });
 

--- a/test/searches/get_value.js
+++ b/test/searches/get_value.js
@@ -152,6 +152,50 @@ describe('get key-value store value', () => {
         scope?.done();
     }).timeout(10000);
 
+    it('throws when an ID-shaped store is not found instead of creating one', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const missingStoreId = 'aBcDeFgHiJkLmNoPq'; // 17-char, ID-shaped
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { storeIdOrName: missingStoreId, key: randomString() },
+        };
+
+        // No POST is mocked, so scope.done() proves no store was created.
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/key-value-stores/${missingStoreId}`)
+            .reply(404, { error: { type: 'record-not-found', message: 'Key-value store was not found' } });
+
+        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle))
+            .to.be.rejectedWith(/does not exist/);
+        scope.done();
+    });
+
+    it('creates a store when a name (not an ID) is not found, then throws because the key is missing', async () => {
+        if (TEST_USER_TOKEN) return; // Only run with nock mocks
+
+        const storeName = 'my-zapier-store';
+        const storeKey = randomString();
+        const createdId = randomString();
+        const bundle = {
+            authData: { access_token: TEST_USER_TOKEN },
+            inputData: { storeIdOrName: storeName, key: storeKey },
+        };
+
+        const scope = nock('https://api.apify.com');
+        scope.get(`/v2/key-value-stores/${storeName}`)
+            .reply(404, { error: { type: 'record-not-found', message: 'Key-value store was not found' } });
+        scope.post('/v2/key-value-stores')
+            .query({ name: storeName })
+            .reply(201, { data: getMockKVStore({ id: createdId }) });
+        scope.head(`/v2/key-value-stores/${createdId}/records/${storeKey}`)
+            .reply(404);
+
+        await expect(appTester(App.searches.keyValueStoreGetValue.operation.perform, bundle))
+            .to.be.rejectedWith(/No record found for key/);
+        scope.done();
+    });
+
     it('work for plain text', async () => {
         const storeKey = randomString();
         const storeValue = 'Just some text.';


### PR DESCRIPTION
Fixes for task https://github.com/apify/apify-zapier-integration/issues/134

fix:

- **Fetch Dataset Items** throws an error when the found dataset has no items
- **Fetch Dataset Items** throws an error when the dataset name or ID does not exist, instead of silently creating a dataset
- **Get Key-Value Store Record** throws an error when the store name or ID does not exist, instead of creating a new store
- **Set Key-Value Store Record** throws an error when an ID-shaped input does not match an existing store, instead of creating a store named like an ID
- Dataset and key-value store names are now resolved via the `~name` API shorthand, so an existing named storage is found without any write side effect

⚠️ Breaking changes:

- **Fetch Dataset Items** now fails instead of returning an empty items array when the target dataset contains no items. Existing Zaps that rely on an empty dataset (items: []) will now error.
- **Fetch Dataset Items** now fails for a dataset name that does not exist.
- **Get Key-Value Store Record** now fails for a store name that does not exist.
- **Set Key-Value Store Record** now fails when the input looks like an Apify ID and no such store exists.

Testable on version `4.6.0`.