### PR TITLE
fix: removed redundant headings in changelod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 4.6.0 / 2026-08-20
-## What's Changed
 * feat: zapier update npm dependencies by @daveomri in https://github.com/apify/apify-zapier-integration/pull/149
 * feat: surface approvalUrl for unapproved full-permission Actors by @daveomri in https://github.com/apify/apify-zapier-integration/pull/150
 * Add UTM params to Apify API-token link by @drobnikj in https://github.com/apify/apify-zapier-integration/pull/160
@@ -9,7 +8,6 @@
 **Full Changelog**: https://github.com/apify/apify-zapier-integration/compare/v4.5.9...v4.6.0
 
 ## 4.5.9 / 2026-07-23
-## What's Changed
 * fix: vulnerabilities by @protoss70
 * fix: form-data vulnerability fix by @JanHranicky
 


### PR DESCRIPTION
zapier CLi scans changelog on every release, its internal tool scans it by heading so GH format like:
```
## 4.6.0 / 2026-08-20
## What's Changed
```
 classifies as an empty/non-existing changelog. 
 
 Removed `## What's Changed` from `CHANGELOG.md` so I can release version with package bumps